### PR TITLE
Add validation for job return type

### DIFF
--- a/src/Immediate.Jobs.Analyzers/DiagnosticIds.cs
+++ b/src/Immediate.Jobs.Analyzers/DiagnosticIds.cs
@@ -13,5 +13,6 @@ internal static class DiagnosticIds
 	public const string IJOB0009MissingQueueDefinition = "IJOB0009";
 	public const string IJOB0010JobCannotBeQueueDefinition = "IJOB0010";
 	public const string IJOB0011QueueConfigurationInvalid = "IJOB0011";
+	public const string IJOB0012JobCannotHaveReturnValue = "IJOB0012";
 	public const string IJOB0020DetachedJobCannotBeAddedToBatch = "IJOB0020";
 }

--- a/src/Immediate.Jobs.Analyzers/JobClassAnalyzer.cs
+++ b/src/Immediate.Jobs.Analyzers/JobClassAnalyzer.cs
@@ -56,6 +56,18 @@ public sealed class JobClassAnalyzer : DiagnosticAnalyzer
 			customTags: [WellKnownDiagnosticTags.NotConfigurable]
 		);
 
+	public static readonly DiagnosticDescriptor JobCannotHaveReturnValue =
+		new(
+			id: DiagnosticIds.IJOB0012JobCannotHaveReturnValue,
+			title: "Job cannot have return value",
+			messageFormat: "Job `{0}` returns `{1}`, but must return `ValueTask`",
+			category: "ImmediateJobs",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true,
+			description: "A job cannot have a return value, since it runs in the background and has no consumer to return the value to.",
+			customTags: [WellKnownDiagnosticTags.NotConfigurable]
+		);
+
 	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
 		ImmutableArray.Create(
 		[
@@ -63,6 +75,7 @@ public sealed class JobClassAnalyzer : DiagnosticAnalyzer
 			CronJobCannotHaveParameters,
 			CronJobConfigurationInvalid,
 			JobNameInvalid,
+			JobCannotHaveReturnValue,
 		]);
 
 	public override void Initialize(AnalysisContext context)
@@ -95,6 +108,18 @@ public sealed class JobClassAnalyzer : DiagnosticAnalyzer
 
 		token.ThrowIfCancellationRequested();
 
+		if (!handleMethod.ReturnType.IsValueTask)
+		{
+			context.ReportDiagnostic(
+				Diagnostic.Create(
+					JobCannotHaveReturnValue,
+					handleMethod.Locations.FirstOrDefault(),
+					context.Symbol.Name,
+					handleMethod.ReturnType.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat)
+				)
+			);
+		}
+
 		AnalyzeJobName(context, jobAttribute);
 		AnalyzeJobConfiguration(context, jobAttribute);
 		AnalyzeCronConfiguration(context, jobAttribute, parameterType);
@@ -102,6 +127,8 @@ public sealed class JobClassAnalyzer : DiagnosticAnalyzer
 
 	private static void AnalyzeJobName(SymbolAnalysisContext context, AttributeData jobAttribute)
 	{
+		context.CancellationToken.ThrowIfCancellationRequested();
+
 		if (jobAttribute.GetJobName(className: context.Symbol.Name).HasNameContent())
 			return;
 
@@ -121,6 +148,8 @@ public sealed class JobClassAnalyzer : DiagnosticAnalyzer
 
 	private static void AnalyzeJobConfiguration(SymbolAnalysisContext context, AttributeData jobAttribute)
 	{
+		context.CancellationToken.ThrowIfCancellationRequested();
+
 		var arguments = jobAttribute.NamedArguments;
 
 		var maxAttempts = arguments.GetIntValue("MaxAttempts", 3);
@@ -234,6 +263,8 @@ public sealed class JobClassAnalyzer : DiagnosticAnalyzer
 
 	private static void AnalyzeCronConfiguration(SymbolAnalysisContext context, AttributeData jobAttribute, ITypeSymbol parameterType)
 	{
+		context.CancellationToken.ThrowIfCancellationRequested();
+
 		var hasPayload = !parameterType.IsEmptyJobRequest;
 		var arguments = jobAttribute.NamedArguments;
 

--- a/src/Immediate.Jobs.Generators/ImmediateJobsGenerator.Transform.cs
+++ b/src/Immediate.Jobs.Generators/ImmediateJobsGenerator.Transform.cs
@@ -16,7 +16,7 @@ public sealed partial class ImmediateJobsGenerator
 		var symbol = (INamedTypeSymbol)context.TargetSymbol;
 		var attributes = symbol.GetAttributes();
 
-		if (symbol.GetValidHandleMethod() is not { } handleMethod)
+		if (symbol.GetValidHandleMethod() is not { ReturnType.IsValueTask: true } handleMethod)
 			return null;
 
 		if (attributes.HandlerAttribute is not { } handlerAttribute)

--- a/tests/Immediate.Jobs.Tests/AnalyzerTests/JobClassAnalyzerTests.cs
+++ b/tests/Immediate.Jobs.Tests/AnalyzerTests/JobClassAnalyzerTests.cs
@@ -228,4 +228,23 @@ public sealed class JobClassAnalyzerTests
 			}
 			"""
 		).RunAsync(TestContext.Current.CancellationToken);
+
+	[Fact]
+	public async Task InvalidReturnTypeShouldTrigger() =>
+		await AnalyzerTestHelpers.CreateAnalyzerTest<JobClassAnalyzer>(
+			"""
+			using System.Threading;
+			using System.Threading.Tasks;
+			using Immediate.Handlers.Shared;
+			using Immediate.Jobs.Shared;
+
+			namespace Dummy;
+
+			[Handler, Job(Name = "my-name")]
+			public sealed partial class Job
+			{
+				private async ValueTask<int> {|IJOB0012:Handle|}(EmptyJobRequest _, CancellationToken token) => 1;
+			}
+			"""
+		).RunAsync(TestContext.Current.CancellationToken);
 }

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/InvalidJobsTests.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/InvalidJobsTests.cs
@@ -39,4 +39,44 @@ public sealed class InvalidJobsTests
 
 		_ = await Utility.VerifyIgnoreImmediateHandlers(result);
 	}
+
+	[Fact]
+	public async Task InvalidReturnTypeDoesNotGenerate()
+	{
+		var result = GeneratorTestHelper.RunGenerator(
+			"""
+			using System.Threading;
+			using System.Threading.Tasks;
+			using Immediate.Handlers.Shared;
+			using Immediate.Jobs.Shared;
+			
+			namespace Dummy;
+			
+			[Handler, Job]
+			public sealed partial class GetUsersQuery
+			{
+				public record Query;
+			
+				private async ValueTask<int> Handle(
+					Query _,
+					CancellationToken token)
+				{
+					return 1;
+				}
+			}
+			""",
+			skippedSteps: ["Jobs"]
+		);
+
+		Assert.Equal(
+			[
+				"Immediate.Handlers.Generators/Immediate.Handlers.Generators.ImmediateHandlersGenerator/IH.Dummy.GetUsersQuery.g.cs",
+				"Immediate.Handlers.Generators/Immediate.Handlers.Generators.ImmediateHandlersGenerator/IH.ServiceCollectionExtensions.g.cs",
+				"Immediate.Jobs.Generators/Immediate.Jobs.Generators.ImmediateJobsGenerator/IJ.ServiceCollectionExtensions.g.cs",
+			],
+			result.GeneratedTrees.Select(t => t.FilePath.Replace('\\', '/'))
+		);
+
+		_ = await Utility.VerifyIgnoreImmediateHandlers(result);
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a new analyzer warning for job handlers that return a value instead of `ValueTask`.
  * Tightened generator validation so handlers with invalid return types are excluded from generated output.

* **Tests**
  * Added analyzer test coverage for invalid handler return types.
  * Added generator test coverage confirming invalid handlers are ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->