### PR TITLE
Fix Dashboard build warnings and batch retry guidance

### DIFF
--- a/docs/batches-and-continuations.md
+++ b/docs/batches-and-continuations.md
@@ -80,7 +80,7 @@ makes intra-batch continuations resolvable before commit.
 a generated `Scheduler`). `Begin()` opens an in-memory buffer; you add work by calling each job
 scheduler's inherited **`AddToBatch`** — the job is the receiver, exactly as with `EnqueueAsync`;
 `CommitAsync` flushes the buffer in one atomic unit. Disposing without committing rolls the buffer
-back — giving Hangfire's "exception before commit ⇒ nothing enqueued" guarantee mechanically.
+back, so failures before commit begins enqueue nothing.
 
 ```csharp
 public sealed class CampaignService(
@@ -101,8 +101,9 @@ public sealed class CampaignService(
 
 `AddToBatch` is inherited from the scheduler's closed `JobScheduler<TPayload>` base, so it is strongly
 typed and needs no generic `Add<T>(scheduler, payload)` seam. If storage is unavailable mid-loop,
-**nothing** was written (the buffer only touches storage at commit), so retrying the whole method
-cannot double-send — the "1000 emails" scenario, solved without duplicate-tracking bookkeeping.
+**nothing** was written because commit has not started. Once `CommitAsync` begins, a transport failure
+can leave its outcome unknown: persistence may have succeeded, so callers retrying the operation need
+idempotency or duplicate tracking.
 
 `AddToBatch` mirrors the scheduler timing surface — immediate, delayed, and absolute-time:
 

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/package-lock.json
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/package-lock.json
@@ -8,8 +8,8 @@
 			"dependencies": {
 				"@lucide/vue": "^1.25.0",
 				"@tanstack/vue-query": "^5.101.4",
-				"@vueuse/core": "^14.3.0",
-				"@vueuse/router": "^14.3.0",
+				"@vueuse/core": "^14.4.0",
+				"@vueuse/router": "^14.4.0",
 				"vue": "^3.5.40",
 				"vue-router": "^5.2.0"
 			},
@@ -2337,14 +2337,14 @@
 			}
 		},
 		"node_modules/@vueuse/core": {
-			"version": "14.3.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.3.0.tgz",
-			"integrity": "sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==",
+			"version": "14.4.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.4.0.tgz",
+			"integrity": "sha512-X4WHz1HlCzCBoYXesUkifzzWBAcZgXG8Fi5iNPQg/epdzOB3gu8Fawj3hvuwYR1nGcXGnvxwYYcUC/71++svtQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/web-bluetooth": "^0.0.21",
-				"@vueuse/metadata": "14.3.0",
-				"@vueuse/shared": "14.3.0"
+				"@vueuse/metadata": "14.4.0",
+				"@vueuse/shared": "14.4.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
@@ -2354,21 +2354,21 @@
 			}
 		},
 		"node_modules/@vueuse/metadata": {
-			"version": "14.3.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.3.0.tgz",
-			"integrity": "sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==",
+			"version": "14.4.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.4.0.tgz",
+			"integrity": "sha512-swx/255R6JyHZFJhx845iz5CRWDZdCfvkZOpACWc5+c5WHcG24mv8gUT1WIdFQaHt6dq79rvILd9QnCWiyVm9g==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/@vueuse/router": {
-			"version": "14.3.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/router/-/router-14.3.0.tgz",
-			"integrity": "sha512-MK7YETFDPyDDF9aSP4W3TzUIHLZ+uq0n/t4VMxOP39e0qGbCZ21ZRsGE93ML84teKtCtPDlN+73CTk2e3xVl9w==",
+			"version": "14.4.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/router/-/router-14.4.0.tgz",
+			"integrity": "sha512-q+dRUKI6xYGT4vNPq2t3fujrXPw2KBFV5Jxhw38liTFzwzGXBYcf8Qdjk7AiQpjEH2xLSin6WVTvj85EEIpo9w==",
 			"license": "MIT",
 			"dependencies": {
-				"@vueuse/shared": "14.3.0"
+				"@vueuse/shared": "14.4.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"
@@ -2379,9 +2379,9 @@
 			}
 		},
 		"node_modules/@vueuse/shared": {
-			"version": "14.3.0",
-			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.3.0.tgz",
-			"integrity": "sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==",
+			"version": "14.4.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.4.0.tgz",
+			"integrity": "sha512-JRgY90Sz8DDtPMsaDflvPMp9xYk69JZAmbuDvAquUVXKr2gEjqtzGNTTthLfckH0BzBqvnu31gb4a8TGLRe79g==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/antfu"

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/package.json
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/package.json
@@ -14,8 +14,8 @@
 	"dependencies": {
 		"@lucide/vue": "^1.25.0",
 		"@tanstack/vue-query": "^5.101.4",
-		"@vueuse/core": "^14.3.0",
-		"@vueuse/router": "^14.3.0",
+		"@vueuse/core": "^14.4.0",
+		"@vueuse/router": "^14.4.0",
 		"vue": "^3.5.40",
 		"vue-router": "^5.2.0"
 	},


### PR DESCRIPTION
## Summary

- upgrade @vueuse/core and @vueuse/router to 14.4.0, which removes the invalid PURE annotations emitted by 14.3.0
- clarify that failures before CommitAsync begins enqueue nothing
- document that a CommitAsync transport failure can have an unknown outcome and retries require idempotency or duplicate tracking

## Validation

- npm run check (lint, type-check, 19 tests)
- npm run build (production build completes without Rollup annotation warnings)
- dotnet build src/Immediate.Jobs.Dashboard/Immediate.Jobs.Dashboard.csproj --no-restore -v minimal (all target frameworks and bundle-size check pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that disposing an uncommitted batch discards buffered work without enqueuing it.
  * Documented that transport failures during commit may leave persistence status unknown, requiring idempotency or duplicate tracking when retrying.

* **Chores**
  * Updated dashboard framework utilities to newer compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->