### PR TITLE
Fix batch cancellation crash when members have dependency chains

### DIFF
--- a/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
+++ b/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
@@ -1231,11 +1231,13 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 			?? throw new KeyNotFoundException($"Batch '{batchId}' was not found.");
 		if (batch.State != BatchState.Executing)
 			throw new ImmediateJobException("Only an executing batch can be cancelled.");
-		var jobs = await Jobs(connection).Where(job => job.BatchId == batchId).ToListAsync(cancellationToken)
-			.ConfigureAwait(false);
-		foreach (var job in jobs)
+		var jobIds = await Jobs(connection).Where(job => job.BatchId == batchId).Select(job => job.Id)
+			.ToArrayAsync(cancellationToken).ConfigureAwait(false);
+		foreach (var jobId in jobIds)
 		{
-			if (IsTerminal(job.State))
+			var job = await Jobs(connection).SingleOrDefaultAsync(item => item.Id == jobId, cancellationToken)
+				.ConfigureAwait(false);
+			if (job is null || IsTerminal(job.State))
 				continue;
 			var oldStamp = job.ConcurrencyStamp;
 			job.State = JobState.Cancelled;

--- a/tests/Immediate.Jobs.StorageTests/LinqToDBSqliteStorageTests.cs
+++ b/tests/Immediate.Jobs.StorageTests/LinqToDBSqliteStorageTests.cs
@@ -799,40 +799,6 @@ public sealed class LinqToDBSqliteStorageTests
 		Assert.Equal(0, batch.Remaining);
 	}
 
-	[Fact]
-	public async Task CancelBatchCancelsMembersWithUnsettledDependencyChain()
-	{
-		var cancellationToken = TestContext.Current.CancellationToken;
-		await using var fixture = await StorageFixture.CreateAsync(cancellationToken);
-		var storage = fixture.CreateStorage();
-		var now = fixture.TimeProvider.GetUtcNow();
-		var parent = CreateJob(now, 1) with { Id = "batch-parent", BatchId = "batch" };
-		var child = CreateJob(now, 2) with
-		{
-			Id = "batch-child",
-			BatchId = "batch",
-			State = JobState.AwaitingContinuation,
-			RemainingDependencies = 1,
-		};
-		await storage.EnqueueBatchAsync(new()
-		{
-			Id = "batch",
-			CreatedAt = now,
-			TotalJobs = 2,
-			PendingCount = 2,
-			State = BatchState.Executing,
-		}, [parent, child], [new() { ChildJobId = child.Id, ParentJobId = parent.Id }], cancellationToken);
-
-		await storage.CancelBatchAsync("batch", cancellationToken);
-
-		Assert.Equal(JobState.Cancelled, (await storage.GetJobStatusAsync(parent.Id, cancellationToken))!.State);
-		Assert.Equal(JobState.Cancelled, (await storage.GetJobStatusAsync(child.Id, cancellationToken))!.State);
-		var batch = Assert.IsType<BatchStatus>(await storage.GetBatchStatusAsync("batch", cancellationToken));
-		Assert.Equal(BatchState.Cancelled, batch.State);
-		Assert.Equal(2, batch.Cancelled);
-		Assert.Equal(0, batch.Remaining);
-	}
-
 	private static JobAcquisitionRequest CreateRequest(string workerId, int batchSize) => new()
 	{
 		WorkerId = workerId,

--- a/tests/Immediate.Jobs.StorageTests/LinqToDBSqliteStorageTests.cs
+++ b/tests/Immediate.Jobs.StorageTests/LinqToDBSqliteStorageTests.cs
@@ -799,6 +799,40 @@ public sealed class LinqToDBSqliteStorageTests
 		Assert.Equal(0, batch.Remaining);
 	}
 
+	[Fact]
+	public async Task CancelBatchCancelsMembersWithUnsettledDependencyChain()
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var fixture = await StorageFixture.CreateAsync(cancellationToken);
+		var storage = fixture.CreateStorage();
+		var now = fixture.TimeProvider.GetUtcNow();
+		var parent = CreateJob(now, 1) with { Id = "batch-parent", BatchId = "batch" };
+		var child = CreateJob(now, 2) with
+		{
+			Id = "batch-child",
+			BatchId = "batch",
+			State = JobState.AwaitingContinuation,
+			RemainingDependencies = 1,
+		};
+		await storage.EnqueueBatchAsync(new()
+		{
+			Id = "batch",
+			CreatedAt = now,
+			TotalJobs = 2,
+			PendingCount = 2,
+			State = BatchState.Executing,
+		}, [parent, child], [new() { ChildJobId = child.Id, ParentJobId = parent.Id }], cancellationToken);
+
+		await storage.CancelBatchAsync("batch", cancellationToken);
+
+		Assert.Equal(JobState.Cancelled, (await storage.GetJobStatusAsync(parent.Id, cancellationToken))!.State);
+		Assert.Equal(JobState.Cancelled, (await storage.GetJobStatusAsync(child.Id, cancellationToken))!.State);
+		var batch = Assert.IsType<BatchStatus>(await storage.GetBatchStatusAsync("batch", cancellationToken));
+		Assert.Equal(BatchState.Cancelled, batch.State);
+		Assert.Equal(2, batch.Cancelled);
+		Assert.Equal(0, batch.Remaining);
+	}
+
 	private static JobAcquisitionRequest CreateRequest(string workerId, int batchSize) => new()
 	{
 		WorkerId = workerId,

--- a/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
+++ b/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
@@ -86,6 +86,45 @@ public sealed class RelationalStorageMatrixTests(StorageContainers containers)
 
 	[Theory]
 	[MemberData(nameof(Matrix))]
+	public async Task CancelBatchCancelsMembersWithUnsettledDependencyChain(DatabaseKind database, AdapterKind adapter)
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var fixture = await CreateFixtureAsync(database, adapter, cancellationToken);
+		var storage = fixture.GraphStorage;
+		var now = fixture.TimeProvider.GetUtcNow();
+		var parent = CreateJob("parent", now) with { BatchId = "batch" };
+		var child = CreateJob("child", now) with
+		{
+			BatchId = "batch",
+			State = JobState.AwaitingContinuation,
+			RemainingDependencies = 1,
+		};
+		await storage.EnqueueBatchAsync(new()
+		{
+			Id = "batch",
+			CreatedAt = now,
+			TotalJobs = 2,
+			PendingCount = 2,
+			State = BatchState.Executing,
+		}, [parent, child], [new()
+		{
+			ChildJobId = child.Id,
+			ParentJobId = parent.Id,
+			Trigger = ContinuationTrigger.Success,
+		}], cancellationToken);
+
+		await storage.CancelBatchAsync("batch", cancellationToken);
+
+		Assert.Equal(JobState.Cancelled, (await storage.GetJobStatusAsync(parent.Id, cancellationToken))!.State);
+		Assert.Equal(JobState.Cancelled, (await storage.GetJobStatusAsync(child.Id, cancellationToken))!.State);
+		var status = Assert.IsType<BatchStatus>(await storage.GetBatchStatusAsync("batch", cancellationToken));
+		Assert.Equal(BatchState.Cancelled, status.State);
+		Assert.Equal(2, status.Cancelled);
+		Assert.Equal(0, status.Remaining);
+	}
+
+	[Theory]
+	[MemberData(nameof(Matrix))]
 	public async Task AdapterHandlesContentionAndLeaseRecovery(DatabaseKind database, AdapterKind adapter)
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;


### PR DESCRIPTION
Closes #51.

`CancelBatchCoreAsync` iterated members from a snapshot taken before cancellation started, but cancelling a member can cascade into its dependent siblings through `PropagateTerminalAsync` and bump their `ConcurrencyStamp`. The loop then failed the stamp check on the stale entity, and since the retry replays the same ordering it always exhausted its attempts and leaked `LostRaceException`.

The loop now snapshots member ids and re-reads each row before acting, same as the propagation path already does, so cascaded members are seen as terminal and skipped. Cross-node conflicts still hit the stamp check and can actually recover on retry now.

Added the repro to `LinqToDBSqliteStorageTests` (fails without the fix) and a matrix theory covering all database/adapter combos - ran it against real Postgres and SQL Server containers, everything green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved batch cancellation to reliably cancel all jobs, including dependent jobs awaiting continuation.
  - Missing or already completed jobs are safely skipped during cancellation.
  - Batch status now correctly reports all affected jobs as cancelled with no remaining jobs.

- **Tests**
  - Added coverage for cancellation across unsettled dependency chains and relational storage configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->