### PR TITLE
Fix fair queue acquisition under retrying execution strategies

### DIFF
--- a/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
+++ b/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
@@ -503,6 +503,30 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 		CancellationToken cancellationToken
 	)
 	{
+		await using var strategyContext = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+		var strategy = strategyContext.Database.CreateExecutionStrategy();
+		return await strategy.ExecuteAsync(
+			operationCancellationToken => AcquireFairCandidateCoreAsync(
+				candidate,
+				workerId,
+				lease,
+				now,
+				nextSequence,
+				operationCancellationToken
+			),
+			cancellationToken
+		).ConfigureAwait(false);
+	}
+
+	private async Task<JobRecord?> AcquireFairCandidateCoreAsync(
+		ImmediateJobEntity candidate,
+		string workerId,
+		TimeSpan lease,
+		DateTimeOffset now,
+		long nextSequence,
+		CancellationToken cancellationToken
+	)
+	{
 		await using var context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 		await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
 		var entity = Copy(candidate);

--- a/tests/Immediate.Jobs.FunctionalTests/Storage/EntityFrameworkCoreJobStorageTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/Storage/EntityFrameworkCoreJobStorageTests.cs
@@ -489,6 +489,29 @@ public sealed class EntityFrameworkCoreJobStorageTests
 	}
 
 	[Fact]
+	public async Task FairQueueAcquisitionRunsInsideConfiguredExecutionStrategy()
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var fixture = await StorageFixture.CreateAsync(
+			cancellationToken,
+			useRetryingExecutionStrategy: true
+		);
+		var storage = fixture.CreateStorage();
+		var now = fixture.TimeProvider.GetUtcNow();
+		await storage.EnqueueAsync(CreateJob(now, 1) with { Id = "a-first", GroupId = "group-a" }, cancellationToken);
+		await storage.EnqueueAsync(CreateJob(now, 2) with { Id = "a-second", GroupId = "group-a" }, cancellationToken);
+		await storage.EnqueueAsync(CreateJob(now, 3) with { Id = "b-first", GroupId = "group-b" }, cancellationToken);
+		var request = CreateFairRequest("fair-worker", 1);
+
+		var first = Assert.Single(await storage.AcquireDueJobsAsync(request, cancellationToken));
+		Assert.Equal("a-first", first.Id);
+		await storage.CompleteAsync(first.Id, "fair-worker", cancellationToken);
+
+		var second = Assert.Single(await storage.AcquireDueJobsAsync(request, cancellationToken));
+		Assert.Equal("b-first", second.Id);
+	}
+
+	[Fact]
 	public async Task RecurringMaterializationRunsInsideConfiguredExecutionStrategy()
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;


### PR DESCRIPTION
Closes #53.

`AcquireFairCandidateAsync` opened a transaction directly on the context, which EF rejects when the configured execution strategy retries on failure. Every other transactional path in the adapter already goes through `CreateExecutionStrategy()`, so with `EnableRetryOnFailure` fair queue acquisition always threw and grouped jobs never ran.

Split it into a wrapper plus `AcquireFairCandidateCoreAsync` running inside the strategy, same shape as `MaterializeRecurringAsync`. The claim body is unchanged, and a replayed claim just loses the stamp check and returns null like any other lost race.

Added a repro next to the other execution strategy tests (fails without the fix). Also ran the fair queue matrix with `EnableRetryOnFailure` on real Postgres and SQL Server containers - fails on both without the fix, green with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when acquiring jobs by handling transient database failures through the configured retry strategy.
  * Preserved fair queue ordering during job acquisition.

* **Tests**
  * Added coverage for fair queue acquisition with a retry-enabled database configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->