### PR TITLE
Fix duplicate and skipped rows when paging jobs

### DIFF
--- a/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
+++ b/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
@@ -978,6 +978,7 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 		}
 
 		var entities = await jobs.OrderByDescending(job => job.CreatedAt)
+			.ThenBy(job => job.Id)
 			.Skip(query.Skip)
 			.Take(query.Take)
 			.ToListAsync(cancellationToken)

--- a/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
+++ b/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
@@ -1062,6 +1062,7 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 		}
 
 		var entities = await jobs.OrderByDescending(job => job.CreatedAt)
+			.ThenBy(job => job.Id)
 			.Skip(query.Skip)
 			.Take(query.Take)
 			.ToListAsync(cancellationToken)

--- a/src/Immediate.Jobs.Shared/InMemoryJobStorage.cs
+++ b/src/Immediate.Jobs.Shared/InMemoryJobStorage.cs
@@ -762,7 +762,10 @@ public sealed class InMemoryJobStorage(TimeProvider timeProvider) :
 
 			return
 			[
-				.. jobs.OrderByDescending(x => x.CreatedAt).Skip(Math.Max(0, query.Skip)).Take(Math.Clamp(query.Take, 1, 1000)),
+				.. jobs.OrderByDescending(x => x.CreatedAt)
+					.ThenBy(x => x.Id, StringComparer.Ordinal)
+					.Skip(Math.Max(0, query.Skip))
+					.Take(Math.Clamp(query.Take, 1, 1000)),
 			];
 		}
 	}

--- a/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
+++ b/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
@@ -144,8 +144,10 @@ public sealed class RelationalStorageMatrixTests(StorageContainers containers)
 			seen.AddRange(page.Select(static job => job.Id));
 		}
 
-		Assert.Equal(30, seen.Count);
-		Assert.Equal(30, seen.Distinct(StringComparer.Ordinal).Count());
+		Assert.Equal(
+			Enumerable.Range(0, 30).Select(static index => $"tied-{index:d2}"),
+			seen
+		);
 	}
 
 	[Theory]

--- a/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
+++ b/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
@@ -128,6 +128,28 @@ public sealed class RelationalStorageMatrixTests(StorageContainers containers)
 
 	[Theory]
 	[MemberData(nameof(Matrix))]
+	public async Task AdapterPagesJobsWithTiedCreationTimesExactlyOnce(DatabaseKind database, AdapterKind adapter)
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var fixture = await CreateFixtureAsync(database, adapter, cancellationToken);
+		var storage = fixture.Storage;
+		var now = fixture.TimeProvider.GetUtcNow();
+		foreach (var index in Enumerable.Range(0, 30).Reverse())
+			await storage.EnqueueAsync(CreateJob($"tied-{index:d2}", now), cancellationToken);
+
+		var seen = new List<string>();
+		for (var skip = 0; skip < 30; skip += 7)
+		{
+			var page = await storage.QueryJobsAsync(new() { Skip = skip, Take = 7 }, cancellationToken);
+			seen.AddRange(page.Select(static job => job.Id));
+		}
+
+		Assert.Equal(30, seen.Count);
+		Assert.Equal(30, seen.Distinct(StringComparer.Ordinal).Count());
+	}
+
+	[Theory]
+	[MemberData(nameof(Matrix))]
 	public async Task AdapterRotatesToAGroupThatArrivesAfterEarlierService(
 		DatabaseKind database,
 		AdapterKind adapter


### PR DESCRIPTION
Closes #57.

`QueryJobsAsync` orders by `CreatedAt` alone before paging in both SQL adapters, so rows that tie can be duplicated or skipped across pages. The batch member queries in the same files already break ties with `ThenBy(Id)`; this applies the same tiebreaker to the paged query, and to the in-memory storage for consistency. Single server recovery pages durable jobs through this query, so a skipped row there is a job missing from memory after a restart.

The regression test runs on the relational matrix: 30 jobs with the same `CreatedAt`, paged 7 at a time. Without the fix Postgres returns 29 distinct ids out of 30 on both adapters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job list pagination stability when multiple jobs share the same creation time.
  * Added deterministic ordering to prevent duplicate or missing jobs across pages.
  * Ensured paginated results consistently include each matching job exactly once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->