### PR TITLE
Cache payload JSON metadata per type

### DIFF
--- a/src/Immediate.Jobs.Shared/JobExecution.cs
+++ b/src/Immediate.Jobs.Shared/JobExecution.cs
@@ -1,6 +1,7 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Immediate.Jobs.Shared;
 
@@ -70,6 +71,8 @@ public interface IJobSerializer
 /// <param name="options">The JSON serializer options shared by generated schedulers and invokers.</param>
 public sealed class SystemTextJsonJobSerializer(JsonSerializerOptions options) : IJobSerializer
 {
+	private readonly ConcurrentDictionary<Type, JsonTypeInfo> _payloadTypeInfos = new();
+
 	/// <summary>Creates a serializer using web defaults.</summary>
 	public SystemTextJsonJobSerializer()
 		: this(new(JsonSerializerDefaults.Web))
@@ -99,7 +102,7 @@ public sealed class SystemTextJsonJobSerializer(JsonSerializerOptions options) :
 	)
 	{
 		ArgumentNullException.ThrowIfNull(payloadTypeInfoFactory);
-		return JsonSerializer.Serialize(payload, payloadTypeInfoFactory(new(Options)));
+		return JsonSerializer.Serialize(payload, GetPayloadTypeInfo(payloadTypeInfoFactory));
 	}
 
 	/// <inheritdoc />
@@ -109,7 +112,16 @@ public sealed class SystemTextJsonJobSerializer(JsonSerializerOptions options) :
 	)
 	{
 		ArgumentNullException.ThrowIfNull(payloadTypeInfoFactory);
-		return JsonSerializer.Deserialize(payload, payloadTypeInfoFactory(new(Options)))
+		return JsonSerializer.Deserialize(payload, GetPayloadTypeInfo(payloadTypeInfoFactory))
 			?? throw new JsonException($"The payload for {typeof(TPayload).FullName} was null.");
 	}
+
+	private JsonTypeInfo<TPayload> GetPayloadTypeInfo<TPayload>(
+		Func<JsonSerializerOptions, JsonTypeInfo<TPayload>> payloadTypeInfoFactory
+	) =>
+		(JsonTypeInfo<TPayload>)_payloadTypeInfos.GetOrAdd(
+			typeof(TPayload),
+			static (_, state) => state.Factory(new(state.Options)),
+			(Factory: payloadTypeInfoFactory, Options)
+		);
 }


### PR DESCRIPTION
Closes #55.

The factory overloads of `SystemTextJsonJobSerializer` called `payloadTypeInfoFactory(new(Options))` on every serialize and deserialize, building a fresh `JsonSerializerOptions` copy and rebinding the generated context each time, which defeats STJ's per-options metadata caching on the hot path of every enqueue and execution. The type info is now cached per payload type, so the options copy and context binding happen once per type.

Benchmark over 200k iterations: serialize goes from 7,547ns and 7,304B per op to 319ns and 176B, deserialize from 3,879ns to 546ns, and Gen0 collections across the run from 174 to 4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved job payload serialization and deserialization efficiency by reusing generated JSON metadata.
* **Reliability**
  * Preserved existing handling for null JSON payloads, including the appropriate serialization exception behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->