### PR TITLE
Drop dead servers from the monitoring snapshot

### DIFF
--- a/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
+++ b/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
@@ -940,8 +940,10 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 			})
 			.ToListAsync(cancellationToken)
 			.ConfigureAwait(false);
+		var cutoff = _timeProvider.GetUtcNow() - TimeSpan.FromMinutes(2);
 		var servers = await context.Set<ImmediateJobServerEntity>()
 			.AsNoTracking()
+			.Where(server => server.LastHeartbeat >= cutoff)
 			.OrderBy(server => server.WorkerId)
 			.Select(server => new JobServerSnapshot(server.WorkerId, server.LastHeartbeat, server.ActiveWorkers, server.MaxWorkers))
 			.ToListAsync(cancellationToken)
@@ -1476,6 +1478,11 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 	{
 		ArgumentNullException.ThrowIfNull(server);
 		await using var context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+		var cutoff = _timeProvider.GetUtcNow() - TimeSpan.FromMinutes(2);
+		_ = await context.Set<ImmediateJobServerEntity>()
+			.Where(item => item.LastHeartbeat < cutoff)
+			.ExecuteDeleteAsync(cancellationToken)
+			.ConfigureAwait(false);
 		var entity = await context.Set<ImmediateJobServerEntity>().FindAsync([server.WorkerId], cancellationToken).ConfigureAwait(false);
 		if (entity is null)
 		{

--- a/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
+++ b/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
@@ -1014,7 +1014,9 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 			.OrderBy(schedule => schedule.Name)
 			.ToListAsync(cancellationToken)
 			.ConfigureAwait(false);
+		var cutoff = (_timeProvider.GetUtcNow() - TimeSpan.FromMinutes(2)).UtcTicks;
 		var serverEntities = await Servers(connection)
+			.Where(server => server.LastHeartbeat >= cutoff)
 			.OrderBy(server => server.WorkerId)
 			.ToListAsync(cancellationToken)
 			.ConfigureAwait(false);
@@ -1467,6 +1469,11 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 	{
 		ArgumentNullException.ThrowIfNull(server);
 		await using var connection = CreateConnection();
+		var cutoff = (_timeProvider.GetUtcNow() - TimeSpan.FromMinutes(2)).UtcTicks;
+		_ = await Servers(connection)
+			.Where(entity => entity.LastHeartbeat < cutoff)
+			.DeleteAsync(cancellationToken)
+			.ConfigureAwait(false);
 		var updated = await Servers(connection)
 			.Where(entity => entity.WorkerId == server.WorkerId)
 			.Set(entity => entity.LastHeartbeat, server.LastHeartbeat.UtcTicks)

--- a/src/Immediate.Jobs.Redis/RedisJobStorage.cs
+++ b/src/Immediate.Jobs.Redis/RedisJobStorage.cs
@@ -433,6 +433,7 @@ public sealed class RedisJobStorage : IRecurringJobStorage, IDisposable
 				server.MaxWorkers,
 				Score(server.LastHeartbeat),
 				server.WorkerId,
+				(long)TimeSpan.FromMinutes(2).TotalMilliseconds,
 			],
 			cancellationToken
 		).ConfigureAwait(false);
@@ -674,12 +675,15 @@ public sealed class RedisJobStorage : IRecurringJobStorage, IDisposable
 		_ = await Task.WhenAll(tasks).WaitAsync(cancellationToken).ConfigureAwait(false);
 		return
 		[
-			.. tasks.Select((task, index) => new JobServerSnapshot(
-				(string)ids[index]!,
-				FromTicks(task.Result[0]),
-				ParseInt32(task.Result[1]),
-				ParseInt32(task.Result[2])
-			)),
+			.. tasks
+				.Select((task, index) => (Id: (string)ids[index]!, Values: task.Result))
+				.Where(static server => !server.Values[0].IsNullOrEmpty)
+				.Select(static server => new JobServerSnapshot(
+					server.Id,
+					FromTicks(server.Values[0]),
+					ParseInt32(server.Values[1]),
+					ParseInt32(server.Values[2])
+				)),
 		];
 	}
 

--- a/src/Immediate.Jobs.Redis/RedisScripts.cs
+++ b/src/Immediate.Jobs.Redis/RedisScripts.cs
@@ -342,6 +342,7 @@ internal static class RedisScripts
 		"""
 		redis.call('HSET', KEYS[1],
 			'last', ARGV[1], 'active', ARGV[2], 'max', ARGV[3])
+		redis.call('PEXPIRE', KEYS[1], ARGV[6])
 		redis.call('ZADD', KEYS[2], ARGV[4], ARGV[5])
 		return 1
 		""";

--- a/tests/Immediate.Jobs.StorageTests/RedisStorageTests.cs
+++ b/tests/Immediate.Jobs.StorageTests/RedisStorageTests.cs
@@ -285,6 +285,39 @@ public sealed class RedisStorageTests(RedisStorageFixture fixture)
 	}
 
 	[Fact]
+	public async Task HeartbeatExpiresServerStateAfterTheLivenessWindow()
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var connection = await ConnectionMultiplexer.ConnectAsync(fixture.Container.GetConnectionString());
+		var timeProvider = CreateTimeProvider();
+		var options = CreateOptions();
+		using var storage = new RedisJobStorage(connection, options, timeProvider);
+		await storage.HeartbeatAsync(new("node-a", timeProvider.GetUtcNow(), 1, 8), cancellationToken);
+
+		var expiry = await connection.GetDatabase(options.Database).KeyTimeToLiveAsync(ServerKey(options, "node-a"));
+
+		Assert.InRange(Assert.NotNull(expiry), TimeSpan.FromSeconds(1), TimeSpan.FromMinutes(2));
+	}
+
+	[Fact]
+	public async Task SnapshotSkipsServersWhoseStateAlreadyExpired()
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var connection = await ConnectionMultiplexer.ConnectAsync(fixture.Container.GetConnectionString());
+		var timeProvider = CreateTimeProvider();
+		var options = CreateOptions();
+		using var storage = new RedisJobStorage(connection, options, timeProvider);
+		var now = timeProvider.GetUtcNow();
+		await storage.HeartbeatAsync(new("node-a", now, 1, 8), cancellationToken);
+		await storage.HeartbeatAsync(new("node-b", now, 2, 8), cancellationToken);
+		_ = await connection.GetDatabase(options.Database).KeyDeleteAsync(ServerKey(options, "node-a"));
+
+		var snapshot = await storage.GetMonitoringSnapshotAsync(cancellationToken);
+
+		Assert.Equal("node-b", Assert.Single(snapshot.Servers).WorkerId);
+	}
+
+	[Fact]
 	public async Task ConcurrentRecurringMaterializationCreatesOneOccurrence()
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;
@@ -418,6 +451,9 @@ public sealed class RedisStorageTests(RedisStorageFixture fixture)
 
 	private static RedisKey CompletedKey(RedisJobStorageOptions options, JobState state) =>
 		$"{{{options.KeyPrefix}}}:completed:{(int)state}";
+
+	private static RedisKey ServerKey(RedisJobStorageOptions options, string workerId) =>
+		$"{{{options.KeyPrefix}}}:server:{workerId}";
 
 	private static JobRecord CreateJob(string id, DateTimeOffset now) => new()
 	{

--- a/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
+++ b/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
@@ -258,6 +258,24 @@ public sealed class RelationalStorageMatrixTests(StorageContainers containers)
 
 	[Theory]
 	[MemberData(nameof(Matrix))]
+	public async Task AdapterDropsServersWithoutARecentHeartbeat(DatabaseKind database, AdapterKind adapter)
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var fixture = await CreateFixtureAsync(database, adapter, cancellationToken);
+		var storage = fixture.Storage;
+		var now = fixture.TimeProvider.GetUtcNow();
+		await storage.HeartbeatAsync(new("node-a", now, 1, 8), cancellationToken);
+		fixture.TimeProvider.Advance(TimeSpan.FromMinutes(3));
+		await storage.HeartbeatAsync(new("node-b", fixture.TimeProvider.GetUtcNow(), 2, 8), cancellationToken);
+
+		var snapshot = await storage.GetMonitoringSnapshotAsync(cancellationToken);
+
+		Assert.Equal("node-b", Assert.Single(snapshot.Servers).WorkerId);
+		Assert.Equal(1, await fixture.CountServersAsync(cancellationToken));
+	}
+
+	[Theory]
+	[MemberData(nameof(Matrix))]
 	public async Task BulkIncomingEdgesPreserveFieldsAndNormalizeInput(
 		DatabaseKind database,
 		AdapterKind adapter
@@ -813,6 +831,25 @@ public sealed class RelationalStorageMatrixTests(StorageContainers containers)
 					{Quote("CancelledCount")} = 0
 				WHERE {Quote("Id")} = '{batchId}'
 				""",
+				cancellationToken
+			);
+		}
+
+		public async ValueTask<int> CountServersAsync(CancellationToken cancellationToken)
+		{
+			var tablePrefix = database switch
+			{
+				DatabaseKind.Sqlite => string.Empty,
+				DatabaseKind.PostgreSql => $"\"{schema}\".",
+				DatabaseKind.SqlServer => $"[{schema}].",
+				_ => throw new InvalidOperationException($"Unknown matrix database '{database}'."),
+			};
+			var serverTable = tablePrefix + (database == DatabaseKind.SqlServer
+				? "[immediate_job_servers]"
+				: "\"immediate_job_servers\"");
+			await using var connection = new global::LinqToDB.Data.DataConnection(dataOptions);
+			return await connection.ExecuteAsync<int>(
+				$"SELECT COUNT(*) FROM {serverTable}",
 				cancellationToken
 			);
 		}


### PR DESCRIPTION
Closes #56.

The in-memory storage drops servers that have not heartbeated for 2 minutes, but the durable adapters kept them forever. EF Core and LinqToDB now filter stale servers out of the snapshot and delete their rows on heartbeat; worker ids are unique per process start, so those tables grew on every restart. Redis already prunes its server listing, but the `server:{id}` hashes lived forever; heartbeat now sets a 2 minute PEXPIRE on the hash, and the snapshot skips a vanished hash instead of throwing `ArgumentNullException`.

Covered by a relational matrix theory plus two Redis facts for the hash TTL and the vanished hash; all of them fail without the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Monitoring now shows only servers with a recent heartbeat.
  * Stale server records are automatically removed during heartbeat updates.
  * Server heartbeat state now expires automatically, improving live-server accuracy.

* **Bug Fixes**
  * Monitoring snapshots no longer include inactive or expired servers.
  * Improved handling of missing server state when reading live server information.

* **Tests**
  * Added coverage for heartbeat expiration, stale-server removal, and monitoring snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->