### PR TITLE
Fix continuation and recurring scheduling correctness issues

### DIFF
--- a/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
+++ b/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
@@ -16,6 +16,7 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 ) : IRecurringJobStorage, IJobGraphStorage, IJobStorageReplica
 	where TContext : DbContext
 {
+	private const int MaxConcurrencyAttempts = 5;
 	private const int MaxConsecutiveFailedFairClaims = 5;
 	private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
 
@@ -94,33 +95,15 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 		await ExecuteGraphInsertAsync(batch, jobs, edges, cancellationToken).ConfigureAwait(false);
 	}
 
-	private async ValueTask ExecuteGraphInsertAsync(
+	private ValueTask ExecuteGraphInsertAsync(
 		JobBatchRecord? batch,
 		IReadOnlyList<JobRecord> jobs,
 		IReadOnlyList<JobContinuationEdge> edges,
 		CancellationToken cancellationToken
-	)
-	{
-		const int MaxConcurrencyAttempts = 5;
-		for (var attempt = 0; attempt < MaxConcurrencyAttempts; attempt++)
-		{
-			try
-			{
-				await using var strategyContext = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-				var strategy = strategyContext.Database.CreateExecutionStrategy();
-				await strategy.ExecuteAsync(
-					operationCancellationToken => InsertGraphCoreAsync(batch, jobs, edges, operationCancellationToken),
-					cancellationToken
-				).ConfigureAwait(false);
-				return;
-			}
-			catch (DbUpdateConcurrencyException) when (attempt + 1 < MaxConcurrencyAttempts)
-			{
-				// A parent completed while its continuation edge was being inserted. Retry so
-				// dependency evaluation observes either the edge or the terminal parent.
-			}
-		}
-	}
+	) => RetryConcurrencyAsync(
+		operationCancellationToken => InsertGraphCoreAsync(batch, jobs, edges, operationCancellationToken),
+		cancellationToken
+	);
 
 	private async Task InsertGraphCoreAsync(
 		JobBatchRecord? batch,
@@ -758,7 +741,7 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 	}
 
 	/// <inheritdoc />
-	public async ValueTask AddBatchJobAsync(
+	public ValueTask AddBatchJobAsync(
 		string currentJobId,
 		JobRecord job,
 		ContinuationOptions options,
@@ -768,28 +751,15 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 		ArgumentNullException.ThrowIfNull(job);
 		if (options == ContinuationOptions.Detached)
 			throw new ImmediateJobException("AddToBatchAsync cannot create a detached job.");
-		const int MaxConcurrencyAttempts = 5;
-		for (var attempt = 0; attempt < MaxConcurrencyAttempts; attempt++)
-		{
-			try
-			{
-				await using var strategyContext = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-				var strategy = strategyContext.Database.CreateExecutionStrategy();
-				await strategy.ExecuteAsync(
-					operationCancellationToken => AddBatchJobCoreAsync(
-						currentJobId,
-						job,
-						options,
-						operationCancellationToken
-					),
-					cancellationToken
-				).ConfigureAwait(false);
-				return;
-			}
-			catch (DbUpdateConcurrencyException) when (attempt + 1 < MaxConcurrencyAttempts)
-			{
-			}
-		}
+		return RetryConcurrencyAsync(
+			operationCancellationToken => AddBatchJobCoreAsync(
+				currentJobId,
+				job,
+				options,
+				operationCancellationToken
+			),
+			cancellationToken
+		);
 	}
 
 	/// <inheritdoc />
@@ -1564,7 +1534,7 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 		}
 	}
 
-	private async ValueTask MutateOwnedWithDependenciesAsync(
+	private ValueTask MutateOwnedWithDependenciesAsync(
 		string jobId,
 		string workerId,
 		string? error,
@@ -1572,33 +1542,34 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 		bool succeeded,
 		IReadOnlyList<JobContinuationAddition> additions,
 		CancellationToken cancellationToken
+	) => RetryConcurrencyAsync(
+		operationCancellationToken => MutateOwnedCoreAsync(
+			jobId,
+			workerId,
+			error,
+			nextRetryAt,
+			succeeded,
+			additions,
+			operationCancellationToken
+		),
+		cancellationToken
+	);
+
+	private async ValueTask RetryConcurrencyAsync(
+		Func<CancellationToken, Task> operation,
+		CancellationToken cancellationToken
 	)
 	{
-		const int MaxConcurrencyAttempts = 5;
 		for (var attempt = 0; attempt < MaxConcurrencyAttempts; attempt++)
 		{
 			try
 			{
-				await using var strategyContext = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-				var strategy = strategyContext.Database.CreateExecutionStrategy();
-				await strategy.ExecuteAsync(
-					operationCancellationToken => MutateOwnedCoreAsync(
-						jobId,
-						workerId,
-						error,
-						nextRetryAt,
-						succeeded,
-						additions,
-						operationCancellationToken
-					),
-					cancellationToken
-				).ConfigureAwait(false);
+				await ExecuteWithStrategyAsync(operation, cancellationToken).ConfigureAwait(false);
 				return;
 			}
 			catch (DbUpdateConcurrencyException) when (attempt + 1 < MaxConcurrencyAttempts)
 			{
-				// A competing parent completion changed a shared child or batch counter. The whole
-				// transaction rolled back, so retrying re-evaluates the graph from durable state.
+				// The transaction rolled back, so the next attempt re-evaluates the graph from durable state.
 			}
 		}
 	}

--- a/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
+++ b/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
@@ -1654,7 +1654,7 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 			.SingleOrDefaultAsync(item => item.Id == jobId && item.State == JobState.Active && item.WorkerId == workerId, cancellationToken)
 			.ConfigureAwait(false);
 		if (job is null)
-			return;
+			throw new ImmediateJobException($"Worker '{workerId}' does not own active job '{jobId}'.");
 
 		var now = _timeProvider.GetUtcNow();
 		job.WorkerId = null;

--- a/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
+++ b/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
@@ -1898,12 +1898,12 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 		CancellationToken cancellationToken
 	)
 	{
-		var parents = new Queue<(ContinuationParentKind Kind, string Id, bool Failed)>();
+		var parents = new Queue<(ContinuationParentKind Kind, string Id, ContinuationParentOutcome Outcome)>();
 		var processed = new HashSet<(ContinuationParentKind Kind, string Id)>();
 		parents.Enqueue((
 			ContinuationParentKind.Job,
 			terminalJob.Id,
-			terminalJob.State == JobState.Failed
+			GetParentOutcome(terminalJob.State)
 		));
 		await UpdateBatchForTerminalJobAsync(context, terminalJob, now, parents, cancellationToken).ConfigureAwait(false);
 
@@ -1912,11 +1912,14 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 			if (!processed.Add((parent.Kind, parent.Id)))
 				continue;
 			var edges = await context.Set<ImmediateJobContinuationEntity>()
-				.Where(edge => edge.ParentKind == parent.Kind && edge.ParentId == parent.Id)
+				.Where(edge => edge.ParentKind == parent.Kind
+					&& edge.ParentId == parent.Id
+					&& edge.ParentOutcome == ContinuationParentOutcome.Unsettled)
 				.ToListAsync(cancellationToken)
 				.ConfigureAwait(false);
 			foreach (var edge in edges)
 			{
+				edge.ParentOutcome = parent.Outcome;
 				var child = await context.Set<ImmediateJobEntity>()
 					.SingleOrDefaultAsync(job => job.Id == edge.ChildJobId, cancellationToken)
 					.ConfigureAwait(false);
@@ -1926,7 +1929,7 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 				if (child.State != JobState.AwaitingContinuation || child.RemainingDependencies <= 0)
 					continue;
 				child.RemainingDependencies--;
-				if (parent.Failed)
+				if (parent.Outcome == ContinuationParentOutcome.Failed)
 					child.FailedDependencies++;
 				if (child.RemainingDependencies == 0)
 				{
@@ -1939,7 +1942,7 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 					{
 						child.State = JobState.Cancelled;
 						child.CompletedAt = now;
-						parents.Enqueue((ContinuationParentKind.Job, child.Id, Failed: false));
+						parents.Enqueue((ContinuationParentKind.Job, child.Id, ContinuationParentOutcome.Other));
 						await UpdateBatchForTerminalJobAsync(context, child, now, parents, cancellationToken).ConfigureAwait(false);
 					}
 					else
@@ -1963,52 +1966,15 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 			.Where(edge => edge.ChildJobId == childJobId)
 			.ToListAsync(cancellationToken)
 			.ConfigureAwait(false);
-		var parentJobIds = edges
-			.Where(static edge => edge.ParentKind == ContinuationParentKind.Job)
-			.Select(static edge => edge.ParentId)
-			.Distinct(StringComparer.Ordinal)
-			.ToArray();
-		var parentBatchIds = edges
-			.Where(static edge => edge.ParentKind == ContinuationParentKind.Batch)
-			.Select(static edge => edge.ParentId)
-			.Distinct(StringComparer.Ordinal)
-			.ToArray();
-		var parentJobs = parentJobIds.Length == 0
-			? []
-			: await context.Set<ImmediateJobEntity>()
-				.Where(job => parentJobIds.Contains(job.Id))
-				.ToDictionaryAsync(job => job.Id, StringComparer.Ordinal, cancellationToken)
-				.ConfigureAwait(false);
-		var parentBatches = parentBatchIds.Length == 0
-			? []
-			: await context.Set<ImmediateJobBatchEntity>()
-				.Where(batch => parentBatchIds.Contains(batch.Id))
-				.ToDictionaryAsync(batch => batch.Id, StringComparer.Ordinal, cancellationToken)
-				.ConfigureAwait(false);
 		var requiresFailure = false;
 		var anyFailed = false;
-		// A missing parent has no success or failure outcome; Complete continuations can still proceed.
 		foreach (var edge in edges)
 		{
-			bool succeeded;
-			bool failed;
-			if (edge.ParentKind == ContinuationParentKind.Job)
-			{
-				var state = parentJobs.TryGetValue(edge.ParentId, out var parentJob) ? parentJob?.State : null;
-				succeeded = state == JobState.Succeeded;
-				failed = state == JobState.Failed;
-			}
-			else
-			{
-				var state = parentBatches.TryGetValue(edge.ParentId, out var parentBatch) ? parentBatch?.State : null;
-				succeeded = state == BatchState.Succeeded;
-				failed = state == BatchState.Failed;
-			}
-
-			if (edge.Trigger == ContinuationTrigger.Success && !succeeded)
+			if (edge.Trigger == ContinuationTrigger.Success
+				&& edge.ParentOutcome != ContinuationParentOutcome.Succeeded)
 				return true;
 			requiresFailure |= edge.Trigger == ContinuationTrigger.Failure;
-			anyFailed |= failed;
+			anyFailed |= edge.ParentOutcome == ContinuationParentOutcome.Failed;
 		}
 
 		return requiresFailure && !anyFailed;
@@ -2018,7 +1984,7 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 		TContext context,
 		ImmediateJobEntity job,
 		DateTimeOffset now,
-		Queue<(ContinuationParentKind Kind, string Id, bool Failed)> parents,
+		Queue<(ContinuationParentKind Kind, string Id, ContinuationParentOutcome Outcome)> parents,
 		CancellationToken cancellationToken
 	)
 	{
@@ -2057,7 +2023,7 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 		parents.Enqueue((
 			ContinuationParentKind.Batch,
 			batch.Id,
-			batch.State == BatchState.Failed
+			GetParentOutcome(batch.State)
 		));
 	}
 
@@ -2124,6 +2090,8 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 						remaining++;
 						continue;
 					}
+
+					edge.ParentOutcome = GetParentOutcome(parentSucceeded, parentFailed);
 
 					if (parentFailed)
 						failedDependencies++;
@@ -2206,6 +2174,35 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 
 	private static bool IsTerminal(JobState state) =>
 		state is JobState.Succeeded or JobState.Failed or JobState.Cancelled;
+
+	private static ContinuationParentOutcome GetParentOutcome(JobState state) => state switch
+	{
+		JobState.Succeeded => ContinuationParentOutcome.Succeeded,
+		JobState.Failed => ContinuationParentOutcome.Failed,
+		JobState.AwaitingContinuation or
+		JobState.AwaitingParameters or
+		JobState.Scheduled or
+		JobState.Pending or
+		JobState.Active or
+		JobState.Cancelled => ContinuationParentOutcome.Other,
+		_ => throw new ArgumentOutOfRangeException(nameof(state), state, "Unknown job state."),
+	};
+
+	private static ContinuationParentOutcome GetParentOutcome(BatchState state) => state switch
+	{
+		BatchState.Succeeded => ContinuationParentOutcome.Succeeded,
+		BatchState.Failed => ContinuationParentOutcome.Failed,
+		BatchState.Executing or BatchState.Cancelled => ContinuationParentOutcome.Other,
+		_ => throw new ArgumentOutOfRangeException(nameof(state), state, "Unknown batch state."),
+	};
+
+	private static ContinuationParentOutcome GetParentOutcome(bool succeeded, bool failed) =>
+		(succeeded, failed) switch
+		{
+			(true, _) => ContinuationParentOutcome.Succeeded,
+			(_, true) => ContinuationParentOutcome.Failed,
+			_ => ContinuationParentOutcome.Other,
+		};
 
 	private static BatchState GetTerminalBatchState(int failed, int cancelled) =>
 		failed != 0 ? BatchState.Failed : cancelled != 0 ? BatchState.Cancelled : BatchState.Succeeded;

--- a/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
+++ b/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
@@ -101,12 +101,25 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 		CancellationToken cancellationToken
 	)
 	{
-		await using var strategyContext = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-		var strategy = strategyContext.Database.CreateExecutionStrategy();
-		await strategy.ExecuteAsync(
-			operationCancellationToken => InsertGraphCoreAsync(batch, jobs, edges, operationCancellationToken),
-			cancellationToken
-		).ConfigureAwait(false);
+		const int MaxConcurrencyAttempts = 5;
+		for (var attempt = 0; attempt < MaxConcurrencyAttempts; attempt++)
+		{
+			try
+			{
+				await using var strategyContext = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+				var strategy = strategyContext.Database.CreateExecutionStrategy();
+				await strategy.ExecuteAsync(
+					operationCancellationToken => InsertGraphCoreAsync(batch, jobs, edges, operationCancellationToken),
+					cancellationToken
+				).ConfigureAwait(false);
+				return;
+			}
+			catch (DbUpdateConcurrencyException) when (attempt + 1 < MaxConcurrencyAttempts)
+			{
+				// A parent completed while its continuation edge was being inserted. Retry so
+				// dependency evaluation observes either the edge or the terminal parent.
+			}
+		}
 	}
 
 	private async Task InsertGraphCoreAsync(
@@ -2039,28 +2052,36 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 			.Where(edge => edge.ParentKind == ContinuationParentKind.Job && !jobs.ContainsKey(edge.ParentId))
 			.Select(static edge => edge.ParentId)
 			.Distinct(StringComparer.Ordinal)
+			.Order(StringComparer.Ordinal)
 			.ToArray();
 		var externalBatchIds = edges
 			.Where(static edge => edge.ParentKind == ContinuationParentKind.Batch)
 			.Select(static edge => edge.ParentId)
 			.Distinct(StringComparer.Ordinal)
+			.Order(StringComparer.Ordinal)
 			.ToArray();
-		var externalJobs = externalJobIds.Length == 0
+		var externalJobEntities = externalJobIds.Length == 0
 			? []
 			: await context.Set<ImmediateJobEntity>()
-				.AsNoTracking()
 				.Where(job => externalJobIds.Contains(job.Id))
-				.ToDictionaryAsync(job => job.Id, job => job.State, StringComparer.Ordinal, cancellationToken)
+				.OrderBy(static job => job.Id)
+				.ToListAsync(cancellationToken)
 				.ConfigureAwait(false);
-		var externalBatches = externalBatchIds.Length == 0
+		var externalBatchEntities = externalBatchIds.Length == 0
 			? []
 			: await context.Set<ImmediateJobBatchEntity>()
-				.AsNoTracking()
 				.Where(batch => externalBatchIds.Contains(batch.Id))
-				.ToDictionaryAsync(batch => batch.Id, batch => batch.State, StringComparer.Ordinal, cancellationToken)
+				.OrderBy(static batch => batch.Id)
+				.ToListAsync(cancellationToken)
 				.ConfigureAwait(false);
+		var externalJobs = externalJobEntities.ToDictionary(job => job.Id, StringComparer.Ordinal);
+		var externalBatches = externalBatchEntities.ToDictionary(batch => batch.Id, StringComparer.Ordinal);
 		if (externalJobs.Count != externalJobIds.Length || externalBatches.Count != externalBatchIds.Length)
 			throw new ImmediateJobException("A continuation parent does not exist.");
+		foreach (var parent in externalJobEntities.Where(parent => !IsTerminal(parent.State)))
+			parent.ConcurrencyStamp = Guid.NewGuid();
+		foreach (var parent in externalBatchEntities.Where(parent => parent.State == BatchState.Executing))
+			parent.ConcurrencyStamp = Guid.NewGuid();
 
 		var incoming = edges.ToLookup(static edge => edge.ChildJobId, StringComparer.Ordinal);
 		var changed = true;
@@ -2124,17 +2145,17 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 	private static (bool Terminal, bool Succeeded, bool Failed) GetParentState(
 		ImmediateJobContinuationEntity edge,
 		Dictionary<string, ImmediateJobEntity> jobs,
-		Dictionary<string, JobState> externalJobs,
-		Dictionary<string, BatchState> externalBatches
+		Dictionary<string, ImmediateJobEntity> externalJobs,
+		Dictionary<string, ImmediateJobBatchEntity> externalBatches
 	)
 	{
 		if (edge.ParentKind == ContinuationParentKind.Batch)
 		{
-			var state = externalBatches[edge.ParentId];
+			var state = externalBatches[edge.ParentId].State;
 			return (state != BatchState.Executing, state == BatchState.Succeeded, state == BatchState.Failed);
 		}
 
-		var jobState = jobs.TryGetValue(edge.ParentId, out var job) ? job.State : externalJobs[edge.ParentId];
+		var jobState = jobs.TryGetValue(edge.ParentId, out var job) ? job.State : externalJobs[edge.ParentId].State;
 		return (IsTerminal(jobState), jobState == JobState.Succeeded, jobState == JobState.Failed);
 	}
 

--- a/src/Immediate.Jobs.EntityFrameworkCore/ImmediateJobsModelBuilderExtensions.cs
+++ b/src/Immediate.Jobs.EntityFrameworkCore/ImmediateJobsModelBuilderExtensions.cs
@@ -117,6 +117,7 @@ public static class ImmediateJobsModelBuilderExtensions
 		_ = entity.Property(edge => edge.ParentKind).HasConversion<short>();
 		_ = entity.Property(edge => edge.ParentId).HasMaxLength(256);
 		_ = entity.Property(edge => edge.Trigger).HasConversion<short>();
+		_ = entity.Property(edge => edge.ParentOutcome).HasConversion<short>();
 		_ = entity.HasOne<ImmediateJobEntity>()
 			.WithMany()
 			.HasForeignKey(edge => edge.ChildJobId)
@@ -161,6 +162,14 @@ internal enum ContinuationParentKind : short
 {
 	Job,
 	Batch,
+}
+
+internal enum ContinuationParentOutcome : short
+{
+	Unsettled,
+	Succeeded,
+	Failed,
+	Other,
 }
 
 internal sealed class ImmediateJobBatchEntity
@@ -220,6 +229,7 @@ internal sealed class ImmediateJobContinuationEntity
 	public ContinuationParentKind ParentKind { get; set; }
 	public string ParentId { get; set; } = null!;
 	public ContinuationTrigger Trigger { get; set; }
+	public ContinuationParentOutcome ParentOutcome { get; set; }
 }
 
 internal sealed class ImmediateRecurringJobEntity

--- a/src/Immediate.Jobs.LinqToDB/LinqToDBEntities.cs
+++ b/src/Immediate.Jobs.LinqToDB/LinqToDBEntities.cs
@@ -9,6 +9,14 @@ internal enum ContinuationParentKind : short
 	Batch,
 }
 
+internal enum ContinuationParentOutcome : short
+{
+	Unsettled,
+	Succeeded,
+	Failed,
+	Other,
+}
+
 [Table(Name = "immediate_job_batches")]
 internal sealed class ImmediateJobBatchEntity
 {
@@ -113,6 +121,8 @@ internal sealed class ImmediateJobContinuationEntity
 	public string ParentId { get; set; } = null!;
 	[Column(DataType = DataType.Int16)]
 	public ContinuationTrigger Trigger { get; set; }
+	[Column(DataType = DataType.Int16)]
+	public ContinuationParentOutcome ParentOutcome { get; set; }
 }
 
 [Table(Name = "immediate_recurring_jobs")]

--- a/src/Immediate.Jobs.LinqToDB/LinqToDBEntities.cs
+++ b/src/Immediate.Jobs.LinqToDB/LinqToDBEntities.cs
@@ -11,10 +11,10 @@ internal enum ContinuationParentKind : short
 
 internal enum ContinuationParentOutcome : short
 {
-	Unsettled,
-	Succeeded,
-	Failed,
-	Other,
+	Unsettled = 0,
+	Succeeded = 1,
+	Failed = 2,
+	Other = 3,
 }
 
 [Table(Name = "immediate_job_batches")]

--- a/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
+++ b/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
@@ -1570,7 +1570,8 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 				terminalGroups,
 				cancellationToken
 			),
-			cancellationToken
+			cancellationToken,
+			maxAttempts: null
 		).ConfigureAwait(false);
 		await CleanupFairQueueGroupsAsync(terminalGroups).ConfigureAwait(false);
 	}
@@ -2155,10 +2156,11 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 
 	private async ValueTask RetryConcurrencyAsync(
 		Func<DataConnection, Task> operation,
-		CancellationToken cancellationToken
+		CancellationToken cancellationToken,
+		int? maxAttempts = MaxConcurrencyAttempts
 	)
 	{
-		for (var attempt = 0; attempt < MaxConcurrencyAttempts; attempt++)
+		for (var attempt = 0; maxAttempts is null || attempt < maxAttempts.Value; attempt++)
 		{
 			await using var connection = CreateConnection();
 			_ = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
@@ -2168,7 +2170,7 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 				await connection.CommitTransactionAsync(cancellationToken).ConfigureAwait(false);
 				return;
 			}
-			catch (LostRaceException) when (attempt + 1 < MaxConcurrencyAttempts)
+			catch (LostRaceException) when (maxAttempts is null || attempt + 1 < maxAttempts.Value)
 			{
 				await connection.RollbackTransactionAsync(cancellationToken).ConfigureAwait(false);
 			}

--- a/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
+++ b/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
@@ -1631,7 +1631,7 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 			)
 			.ConfigureAwait(false);
 		if (job is null)
-			return;
+			throw new ImmediateJobException($"Worker '{workerId}' does not own active job '{jobId}'.");
 
 		var oldStamp = job.ConcurrencyStamp;
 		var now = _timeProvider.GetUtcNow().UtcTicks;

--- a/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
+++ b/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
@@ -107,7 +107,18 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 		return ExecuteGraphInsertAsync(batch, jobs, edges, cancellationToken);
 	}
 
-	private async ValueTask ExecuteGraphInsertAsync(
+	private ValueTask ExecuteGraphInsertAsync(
+		JobBatchRecord? batch,
+		IReadOnlyList<JobRecord> jobs,
+		IReadOnlyList<JobContinuationEdge> edges,
+		CancellationToken cancellationToken
+	) => RetryConcurrencyAsync(
+		connection => InsertGraphCoreAsync(connection, batch, jobs, edges, cancellationToken),
+		cancellationToken
+	);
+
+	private async Task InsertGraphCoreAsync(
+		DataConnection connection,
 		JobBatchRecord? batch,
 		IReadOnlyList<JobRecord> jobs,
 		IReadOnlyList<JobContinuationEdge> edges,
@@ -127,53 +138,42 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 			throw new ImmediateJobException("Duplicate continuation edges are not allowed.");
 		ThrowIfCyclic(jobIds, edgeEntities);
 
-		await using var connection = CreateConnection();
-		_ = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-		try
-		{
-			var jobEntities = jobs.Select(ToEntity).ToDictionary(static job => job.Id, StringComparer.Ordinal);
-			await ResetReturningGroupCursorsAsync(connection, jobs, cancellationToken).ConfigureAwait(false);
-			await EvaluateInitialDependenciesAsync(
-				connection,
-				jobEntities,
-				edgeEntities,
-				_timeProvider.GetUtcNow().UtcTicks,
-				cancellationToken
-			).ConfigureAwait(false);
+		var jobEntities = jobs.Select(ToEntity).ToDictionary(static job => job.Id, StringComparer.Ordinal);
+		await ResetReturningGroupCursorsAsync(connection, jobs, cancellationToken).ConfigureAwait(false);
+		await EvaluateInitialDependenciesAsync(
+			connection,
+			jobEntities,
+			edgeEntities,
+			_timeProvider.GetUtcNow().UtcTicks,
+			cancellationToken
+		).ConfigureAwait(false);
 
-			if (batch is not null)
+		if (batch is not null)
+		{
+			var terminal = jobEntities.Values.Where(static job => IsTerminal(job.State)).ToArray();
+			var pending = jobEntities.Count - terminal.Length;
+			var failed = terminal.Count(static job => job.State == JobState.Failed);
+			var cancelled = terminal.Count(static job => job.State == JobState.Cancelled);
+			_ = await InsertAsync(connection, new ImmediateJobBatchEntity
 			{
-				var terminal = jobEntities.Values.Where(static job => IsTerminal(job.State)).ToArray();
-				var pending = jobEntities.Count - terminal.Length;
-				var failed = terminal.Count(static job => job.State == JobState.Failed);
-				var cancelled = terminal.Count(static job => job.State == JobState.Cancelled);
-				_ = await InsertAsync(connection, new ImmediateJobBatchEntity
-				{
-					Id = batch.Id,
-					CreatedAt = batch.CreatedAt.UtcTicks,
-					TotalJobs = jobEntities.Count,
-					PendingCount = pending,
-					SucceededCount = terminal.Count(static job => job.State == JobState.Succeeded),
-					FailedCount = failed,
-					CancelledCount = cancelled,
-					StartedAt = Ticks(batch.StartedAt),
-					CompletedAt = pending == 0 ? Ticks(batch.CompletedAt ?? _timeProvider.GetUtcNow()) : null,
-					State = pending == 0 ? GetTerminalBatchState(failed, cancelled) : BatchState.Executing,
-					ConcurrencyStamp = Guid.NewGuid(),
-				}, cancellationToken).ConfigureAwait(false);
-			}
+				Id = batch.Id,
+				CreatedAt = batch.CreatedAt.UtcTicks,
+				TotalJobs = jobEntities.Count,
+				PendingCount = pending,
+				SucceededCount = terminal.Count(static job => job.State == JobState.Succeeded),
+				FailedCount = failed,
+				CancelledCount = cancelled,
+				StartedAt = Ticks(batch.StartedAt),
+				CompletedAt = pending == 0 ? Ticks(batch.CompletedAt ?? _timeProvider.GetUtcNow()) : null,
+				State = pending == 0 ? GetTerminalBatchState(failed, cancelled) : BatchState.Executing,
+				ConcurrencyStamp = Guid.NewGuid(),
+			}, cancellationToken).ConfigureAwait(false);
+		}
 
-			foreach (var entity in jobEntities.Values)
-				_ = await InsertAsync(connection, entity, cancellationToken).ConfigureAwait(false);
-			foreach (var edge in edgeEntities)
-				_ = await InsertAsync(connection, edge, cancellationToken).ConfigureAwait(false);
-			await connection.CommitTransactionAsync(cancellationToken).ConfigureAwait(false);
-		}
-		catch
-		{
-			await connection.RollbackTransactionAsync(cancellationToken).ConfigureAwait(false);
-			throw;
-		}
+		foreach (var entity in jobEntities.Values)
+			_ = await InsertAsync(connection, entity, cancellationToken).ConfigureAwait(false);
+		foreach (var edge in edgeEntities)
+			_ = await InsertAsync(connection, edge, cancellationToken).ConfigureAwait(false);
 	}
 
 	/// <inheritdoc />
@@ -2003,22 +2003,45 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 			.Where(edge => edge.ParentKind == ContinuationParentKind.Job && !jobs.ContainsKey(edge.ParentId))
 			.Select(static edge => edge.ParentId)
 			.Distinct(StringComparer.Ordinal)
+			.Order(StringComparer.Ordinal)
 			.ToArray();
 		var externalBatchIds = edges
 			.Where(static edge => edge.ParentKind == ContinuationParentKind.Batch)
 			.Select(static edge => edge.ParentId)
 			.Distinct(StringComparer.Ordinal)
+			.Order(StringComparer.Ordinal)
 			.ToArray();
-		var externalJobs = externalJobIds.Length == 0
+		var externalJobEntities = externalJobIds.Length == 0
 			? []
 			: (await Jobs(connection).Where(job => externalJobIds.Contains(job.Id)).ToListAsync(cancellationToken)
-				.ConfigureAwait(false)).ToDictionary(job => job.Id, job => job.State, StringComparer.Ordinal);
-		var externalBatches = externalBatchIds.Length == 0
+				.ConfigureAwait(false)).ToDictionary(job => job.Id, StringComparer.Ordinal);
+		var externalBatchEntities = externalBatchIds.Length == 0
 			? []
 			: (await Batches(connection).Where(batch => externalBatchIds.Contains(batch.Id)).ToListAsync(cancellationToken)
-				.ConfigureAwait(false)).ToDictionary(batch => batch.Id, batch => batch.State, StringComparer.Ordinal);
-		if (externalJobs.Count != externalJobIds.Length || externalBatches.Count != externalBatchIds.Length)
+				.ConfigureAwait(false)).ToDictionary(batch => batch.Id, StringComparer.Ordinal);
+		if (externalJobEntities.Count != externalJobIds.Length || externalBatchEntities.Count != externalBatchIds.Length)
 			throw new ImmediateJobException("A continuation parent does not exist.");
+		foreach (var parentId in externalJobIds)
+		{
+			var parent = externalJobEntities[parentId];
+			if (IsTerminal(parent.State))
+				continue;
+			var oldStamp = parent.ConcurrencyStamp;
+			parent.ConcurrencyStamp = Guid.NewGuid();
+			if (!await UpdateJobAsync(connection, parent, oldStamp, cancellationToken).ConfigureAwait(false))
+				throw new LostRaceException();
+		}
+
+		foreach (var parentId in externalBatchIds)
+		{
+			var parent = externalBatchEntities[parentId];
+			if (parent.State != BatchState.Executing)
+				continue;
+			var oldStamp = parent.ConcurrencyStamp;
+			parent.ConcurrencyStamp = Guid.NewGuid();
+			if (!await UpdateBatchAsync(connection, parent, oldStamp, cancellationToken).ConfigureAwait(false))
+				throw new LostRaceException();
+		}
 
 		var incoming = edges.ToLookup(static edge => edge.ChildJobId, StringComparer.Ordinal);
 		var changed = true;
@@ -2039,8 +2062,8 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 					var (terminal, parentSucceeded, parentFailed) = GetParentState(
 						edge,
 						jobs,
-						externalJobs,
-						externalBatches
+						externalJobEntities,
+						externalBatchEntities
 					);
 					requiresFailure |= edge.Trigger == ContinuationTrigger.Failure;
 					if (!terminal)
@@ -2082,17 +2105,17 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 	private static (bool Terminal, bool Succeeded, bool Failed) GetParentState(
 		ImmediateJobContinuationEntity edge,
 		Dictionary<string, ImmediateJobEntity> jobs,
-		Dictionary<string, JobState> externalJobs,
-		Dictionary<string, BatchState> externalBatches
+		Dictionary<string, ImmediateJobEntity> externalJobs,
+		Dictionary<string, ImmediateJobBatchEntity> externalBatches
 	)
 	{
 		if (edge.ParentKind == ContinuationParentKind.Batch)
 		{
-			var state = externalBatches[edge.ParentId];
+			var state = externalBatches[edge.ParentId].State;
 			return (state != BatchState.Executing, state == BatchState.Succeeded, state == BatchState.Failed);
 		}
 
-		var jobState = jobs.TryGetValue(edge.ParentId, out var job) ? job.State : externalJobs[edge.ParentId];
+		var jobState = jobs.TryGetValue(edge.ParentId, out var job) ? job.State : externalJobs[edge.ParentId].State;
 		return (IsTerminal(jobState), jobState == JobState.Succeeded, jobState == JobState.Failed);
 	}
 

--- a/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
+++ b/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
@@ -11,6 +11,7 @@ namespace Immediate.Jobs.LinqToDB;
 /// <summary>An optimistic-concurrency LinqToDB implementation of <see cref="IJobStorage"/>.</summary>
 public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage, IJobStorageReplica
 {
+	private const int MaxContendedCompletionAttempts = 50;
 	private const int MaxConcurrencyAttempts = 5;
 	private const int MaxConsecutiveFailedFairClaims = 5;
 	private readonly DataOptions _dataOptions;
@@ -860,7 +861,7 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 	)
 	{
 		ArgumentNullException.ThrowIfNull(schedule);
-		while (true)
+		for (var attempt = 0; attempt < MaxConcurrencyAttempts; attempt++)
 		{
 			await using var connection = CreateConnection();
 			var existing = await Recurring(connection).SingleOrDefaultAsync(item => item.Name == schedule.Name, cancellationToken)
@@ -892,7 +893,11 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 			existing.ConcurrencyStamp = Guid.NewGuid();
 			if (await UpdateRecurringAsync(connection, existing, oldStamp, cancellationToken).ConfigureAwait(false))
 				return;
+			if (attempt + 1 < MaxConcurrencyAttempts)
+				await DelayConcurrencyRetryAsync(cancellationToken).ConfigureAwait(false);
 		}
+
+		throw new ImmediateJobException($"Recurring schedule '{schedule.Name}' could not be upserted under contention.");
 	}
 
 	/// <inheritdoc />
@@ -1575,7 +1580,7 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 				cancellationToken
 			),
 			cancellationToken,
-			maxAttempts: null
+			maxAttempts: MaxContendedCompletionAttempts
 		).ConfigureAwait(false);
 		await CleanupFairQueueGroupsAsync(terminalGroups).ConfigureAwait(false);
 	}
@@ -2161,10 +2166,10 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 	private async ValueTask RetryConcurrencyAsync(
 		Func<DataConnection, Task> operation,
 		CancellationToken cancellationToken,
-		int? maxAttempts = MaxConcurrencyAttempts
+		int maxAttempts = MaxConcurrencyAttempts
 	)
 	{
-		for (var attempt = 0; maxAttempts is null || attempt < maxAttempts.Value; attempt++)
+		for (var attempt = 0; attempt < maxAttempts; attempt++)
 		{
 			await using var connection = CreateConnection();
 			_ = await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
@@ -2174,9 +2179,10 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 				await connection.CommitTransactionAsync(cancellationToken).ConfigureAwait(false);
 				return;
 			}
-			catch (LostRaceException) when (maxAttempts is null || attempt + 1 < maxAttempts.Value)
+			catch (LostRaceException) when (attempt + 1 < maxAttempts)
 			{
 				await connection.RollbackTransactionAsync(cancellationToken).ConfigureAwait(false);
+				await DelayConcurrencyRetryAsync(cancellationToken).ConfigureAwait(false);
 			}
 			catch
 			{
@@ -2185,6 +2191,9 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 			}
 		}
 	}
+
+	private static Task DelayConcurrencyRetryAsync(CancellationToken cancellationToken) =>
+		Task.Delay(Random.Shared.Next(1, 6), cancellationToken);
 
 	private async Task<bool> UpdateJobAsync(
 		DataConnection connection,

--- a/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
+++ b/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
@@ -860,35 +860,39 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 	)
 	{
 		ArgumentNullException.ThrowIfNull(schedule);
-		await using var connection = CreateConnection();
-		var existing = await Recurring(connection).SingleOrDefaultAsync(item => item.Name == schedule.Name, cancellationToken)
-			.ConfigureAwait(false);
-		if (existing is null)
+		while (true)
 		{
-			try
+			await using var connection = CreateConnection();
+			var existing = await Recurring(connection).SingleOrDefaultAsync(item => item.Name == schedule.Name, cancellationToken)
+				.ConfigureAwait(false);
+			if (existing is null)
 			{
-				_ = await InsertAsync(connection, ToEntity(schedule), cancellationToken).ConfigureAwait(false);
-				return;
+				try
+				{
+					_ = await InsertAsync(connection, ToEntity(schedule), cancellationToken).ConfigureAwait(false);
+					return;
+				}
+				catch (DbException)
+				{
+					existing = await Recurring(connection).SingleOrDefaultAsync(item => item.Name == schedule.Name, cancellationToken)
+						.ConfigureAwait(false);
+					if (existing is null)
+						throw;
+				}
 			}
-			catch (DbException)
-			{
-				existing = await Recurring(connection).SingleOrDefaultAsync(item => item.Name == schedule.Name, cancellationToken)
-					.ConfigureAwait(false);
-				if (existing is null)
-					throw;
-			}
-		}
 
-		if (!schedule.IsCodeDefined && existing.IsCodeDefined)
-			throw new ImmediateJobException("Code-defined recurring schedules cannot be replaced by dynamic schedules.");
-		var oldStamp = existing.ConcurrencyStamp;
-		existing.JobName = schedule.JobName;
-		existing.Cron = schedule.Cron;
-		existing.TimeZone = schedule.TimeZone;
-		existing.IsCodeDefined = schedule.IsCodeDefined;
-		existing.NextRunAt = schedule.NextRunAt.UtcTicks;
-		existing.ConcurrencyStamp = Guid.NewGuid();
-		_ = await UpdateRecurringAsync(connection, existing, oldStamp, cancellationToken).ConfigureAwait(false);
+			if (!schedule.IsCodeDefined && existing.IsCodeDefined)
+				throw new ImmediateJobException("Code-defined recurring schedules cannot be replaced by dynamic schedules.");
+			var oldStamp = existing.ConcurrencyStamp;
+			existing.JobName = schedule.JobName;
+			existing.Cron = schedule.Cron;
+			existing.TimeZone = schedule.TimeZone;
+			existing.IsCodeDefined = schedule.IsCodeDefined;
+			existing.NextRunAt = schedule.NextRunAt.UtcTicks;
+			existing.ConcurrencyStamp = Guid.NewGuid();
+			if (await UpdateRecurringAsync(connection, existing, oldStamp, cancellationToken).ConfigureAwait(false))
+				return;
+		}
 	}
 
 	/// <inheritdoc />

--- a/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
+++ b/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
@@ -1839,13 +1839,12 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 	)
 	{
 		AddFairQueueGroup(terminalGroups, terminalJob);
-		var parents = new Queue<(ContinuationParentKind Kind, string Id, bool Succeeded, bool Failed)>();
+		var parents = new Queue<(ContinuationParentKind Kind, string Id, ContinuationParentOutcome Outcome)>();
 		var processed = new HashSet<(ContinuationParentKind Kind, string Id)>();
 		parents.Enqueue((
 			ContinuationParentKind.Job,
 			terminalJob.Id,
-			terminalJob.State == JobState.Succeeded,
-			terminalJob.State == JobState.Failed
+			GetParentOutcome(terminalJob.State)
 		));
 		await UpdateBatchForTerminalJobAsync(connection, terminalJob, now, parents, cancellationToken)
 			.ConfigureAwait(false);
@@ -1855,11 +1854,23 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 			if (!processed.Add((parent.Kind, parent.Id)))
 				continue;
 			var edges = await Continuations(connection)
-				.Where(edge => edge.ParentKind == parent.Kind && edge.ParentId == parent.Id)
+				.Where(edge => edge.ParentKind == parent.Kind
+					&& edge.ParentId == parent.Id
+					&& edge.ParentOutcome == ContinuationParentOutcome.Unsettled)
 				.ToListAsync(cancellationToken)
 				.ConfigureAwait(false);
 			foreach (var edge in edges)
 			{
+				var settled = await Continuations(connection)
+					.Where(entity => entity.ChildJobId == edge.ChildJobId
+						&& entity.ParentKind == edge.ParentKind
+						&& entity.ParentId == edge.ParentId
+						&& entity.ParentOutcome == ContinuationParentOutcome.Unsettled)
+					.Set(entity => entity.ParentOutcome, parent.Outcome)
+					.UpdateAsync(cancellationToken)
+					.ConfigureAwait(false);
+				if (settled == 0)
+					continue;
 				var child = await Jobs(connection).SingleOrDefaultAsync(job => job.Id == edge.ChildJobId, cancellationToken)
 					.ConfigureAwait(false);
 				if (child is null || IsTerminal(child.State))
@@ -1868,7 +1879,7 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 				if (child.State != JobState.AwaitingContinuation || child.RemainingDependencies <= 0)
 					continue;
 				child.RemainingDependencies--;
-				if (parent.Failed)
+				if (parent.Outcome == ContinuationParentOutcome.Failed)
 					child.FailedDependencies++;
 				if (child.RemainingDependencies == 0)
 				{
@@ -1879,7 +1890,7 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 						child.WorkerId = null;
 						child.LeaseExpiresAt = null;
 						AddFairQueueGroup(terminalGroups, child);
-						parents.Enqueue((ContinuationParentKind.Job, child.Id, Succeeded: false, Failed: false));
+						parents.Enqueue((ContinuationParentKind.Job, child.Id, ContinuationParentOutcome.Other));
 						await UpdateBatchForTerminalJobAsync(connection, child, now, parents, cancellationToken)
 							.ConfigureAwait(false);
 					}
@@ -1906,55 +1917,15 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 			.Where(edge => edge.ChildJobId == childJobId)
 			.ToListAsync(cancellationToken)
 			.ConfigureAwait(false);
-		var jobParentIds = edges
-			.Where(static edge => edge.ParentKind == ContinuationParentKind.Job)
-			.Select(static edge => edge.ParentId)
-			.Distinct(StringComparer.Ordinal)
-			.ToArray();
-		var batchParentIds = edges
-			.Where(static edge => edge.ParentKind == ContinuationParentKind.Batch)
-			.Select(static edge => edge.ParentId)
-			.Distinct(StringComparer.Ordinal)
-			.ToArray();
-		var jobStates = jobParentIds.Length == 0
-			? []
-			: await Jobs(connection)
-				.Where(job => jobParentIds.Contains(job.Id))
-				.Select(static job => new { job.Id, job.State })
-				.ToDictionaryAsync(static job => job.Id, static job => job.State, StringComparer.Ordinal, cancellationToken)
-				.ConfigureAwait(false);
-		var batchStates = batchParentIds.Length == 0
-			? []
-			: await Batches(connection)
-				.Where(batch => batchParentIds.Contains(batch.Id))
-				.Select(static batch => new { batch.Id, batch.State })
-				.ToDictionaryAsync(static batch => batch.Id, static batch => batch.State, StringComparer.Ordinal, cancellationToken)
-				.ConfigureAwait(false);
-
 		var requiresFailure = false;
 		var anyParentFailed = false;
-		// A missing parent has no success or failure outcome; Complete continuations can still proceed.
 		foreach (var edge in edges)
 		{
-			bool succeeded;
-			bool failed;
-			if (edge.ParentKind == ContinuationParentKind.Job)
-			{
-				JobState? state = jobStates.TryGetValue(edge.ParentId, out var parentState) ? parentState : null;
-				succeeded = state == JobState.Succeeded;
-				failed = state == JobState.Failed;
-			}
-			else
-			{
-				BatchState? state = batchStates.TryGetValue(edge.ParentId, out var parentState) ? parentState : null;
-				succeeded = state == BatchState.Succeeded;
-				failed = state == BatchState.Failed;
-			}
-
-			if (edge.Trigger == ContinuationTrigger.Success && !succeeded)
+			if (edge.Trigger == ContinuationTrigger.Success
+				&& edge.ParentOutcome != ContinuationParentOutcome.Succeeded)
 				return true;
 			requiresFailure |= edge.Trigger == ContinuationTrigger.Failure;
-			anyParentFailed |= failed;
+			anyParentFailed |= edge.ParentOutcome == ContinuationParentOutcome.Failed;
 		}
 
 		return requiresFailure && !anyParentFailed;
@@ -1973,7 +1944,7 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 		DataConnection connection,
 		ImmediateJobEntity job,
 		long now,
-		Queue<(ContinuationParentKind Kind, string Id, bool Succeeded, bool Failed)> parents,
+		Queue<(ContinuationParentKind Kind, string Id, ContinuationParentOutcome Outcome)> parents,
 		CancellationToken cancellationToken
 	)
 	{
@@ -2012,8 +1983,7 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 			parents.Enqueue((
 				ContinuationParentKind.Batch,
 				batch.Id,
-				batch.State == BatchState.Succeeded,
-				batch.State == BatchState.Failed
+				GetParentOutcome(batch.State)
 			));
 		}
 
@@ -2078,6 +2048,8 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 						remaining++;
 						continue;
 					}
+
+					edge.ParentOutcome = GetParentOutcome(parentSucceeded, parentFailed);
 
 					if (parentFailed)
 						failedDependencies++;
@@ -2314,6 +2286,35 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 
 	private static bool IsTerminal(JobState state) =>
 		state is JobState.Succeeded or JobState.Failed or JobState.Cancelled;
+
+	private static ContinuationParentOutcome GetParentOutcome(JobState state) => state switch
+	{
+		JobState.Succeeded => ContinuationParentOutcome.Succeeded,
+		JobState.Failed => ContinuationParentOutcome.Failed,
+		JobState.AwaitingContinuation or
+		JobState.AwaitingParameters or
+		JobState.Scheduled or
+		JobState.Pending or
+		JobState.Active or
+		JobState.Cancelled => ContinuationParentOutcome.Other,
+		_ => throw new ArgumentOutOfRangeException(nameof(state), state, "Unknown job state."),
+	};
+
+	private static ContinuationParentOutcome GetParentOutcome(BatchState state) => state switch
+	{
+		BatchState.Succeeded => ContinuationParentOutcome.Succeeded,
+		BatchState.Failed => ContinuationParentOutcome.Failed,
+		BatchState.Executing or BatchState.Cancelled => ContinuationParentOutcome.Other,
+		_ => throw new ArgumentOutOfRangeException(nameof(state), state, "Unknown batch state."),
+	};
+
+	private static ContinuationParentOutcome GetParentOutcome(bool succeeded, bool failed) =>
+		(succeeded, failed) switch
+		{
+			(true, _) => ContinuationParentOutcome.Succeeded,
+			(_, true) => ContinuationParentOutcome.Failed,
+			_ => ContinuationParentOutcome.Other,
+		};
 
 	private static BatchState GetTerminalBatchState(int failed, int cancelled)
 	{

--- a/src/Immediate.Jobs.LinqToDB/LinqToDBSchemaExtensions.cs
+++ b/src/Immediate.Jobs.LinqToDB/LinqToDBSchemaExtensions.cs
@@ -98,7 +98,7 @@ public static class LinqToDBSchemaExtensions
 		);
 		CREATE TABLE IF NOT EXISTS "immediate_job_continuations" (
 			"ChildJobId" TEXT NOT NULL, "ParentKind" INTEGER NOT NULL, "ParentId" TEXT NOT NULL,
-			"Trigger" INTEGER NOT NULL,
+			"Trigger" INTEGER NOT NULL, "ParentOutcome" INTEGER NOT NULL,
 			CONSTRAINT "PK_immediate_job_continuations" PRIMARY KEY ("ChildJobId", "ParentKind", "ParentId"),
 			CONSTRAINT "FK_immediate_job_continuations_immediate_jobs_ChildJobId" FOREIGN KEY ("ChildJobId")
 				REFERENCES "immediate_jobs" ("Id") ON DELETE CASCADE

--- a/src/Immediate.Jobs.Redis/RedisJobStorage.cs
+++ b/src/Immediate.Jobs.Redis/RedisJobStorage.cs
@@ -541,10 +541,36 @@ public sealed class RedisJobStorage : IRecurringJobStorage, IDisposable
 			stop: Score(now),
 			take: batchSize
 		).WaitAsync(cancellationToken).ConfigureAwait(false);
-		return await ReadRecurringAsync(
-			[.. values.Select(static value => ((string)value!)[20..])],
+		var members = values.Select(static value => (string)value!).ToArray();
+		var schedules = await ReadRecurringAsync(
+			[.. members.Select(static member => member[20..])],
 			cancellationToken
 		).ConfigureAwait(false);
+		var schedulesByName = schedules.ToDictionary(static schedule => schedule.Name, StringComparer.Ordinal);
+		var due = new List<RecurringJobSchedule>(schedules.Count);
+		var added = new HashSet<string>(StringComparer.Ordinal);
+		var stale = new List<RedisValue>();
+		foreach (var member in members)
+		{
+			var name = member[20..];
+			if (!schedulesByName.TryGetValue(name, out var schedule)
+				|| !string.Equals(member, RecurringDueMember(schedule.NextRunAt, name), StringComparison.Ordinal))
+			{
+				stale.Add(member);
+				continue;
+			}
+
+			if (added.Add(name))
+				due.Add(schedule);
+		}
+
+		if (stale.Count != 0)
+		{
+			_ = await _database.SortedSetRemoveAsync(RecurringDueKey, [.. stale])
+				.WaitAsync(cancellationToken).ConfigureAwait(false);
+		}
+
+		return due;
 	}
 
 	/// <inheritdoc />
@@ -557,7 +583,7 @@ public sealed class RedisJobStorage : IRecurringJobStorage, IDisposable
 	{
 		ValidateRecurring(schedule);
 		ValidateMaterializedJob(job);
-		var jobArguments = CreateMaterializeArguments(schedule, job, nextRunAt);
+		var jobArguments = CreateMaterializeArguments(schedule, job, nextRunAt, _timeProvider.GetUtcNow());
 		var result = await EvaluateInt64Async(
 			RedisScripts.MaterializeRecurring,
 			[
@@ -610,17 +636,10 @@ public sealed class RedisJobStorage : IRecurringJobStorage, IDisposable
 	)
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(name);
-		var schedule = await ReadRecurringAsync(name, cancellationToken).ConfigureAwait(false)
-			?? throw new KeyNotFoundException($"Recurring schedule '{name}' was not found.");
 		var result = await EvaluateInt64Async(
 			RedisScripts.SetRecurringPaused,
 			[RecurringKey(name), RecurringDueKey],
-			[
-				isPaused ? 1 : 0,
-				name,
-				Score(schedule.NextRunAt),
-				RecurringDueMember(schedule.NextRunAt, name),
-			],
+			[isPaused ? 1 : 0],
 			cancellationToken
 		).ConfigureAwait(false);
 		if (result == 0)
@@ -833,7 +852,8 @@ public sealed class RedisJobStorage : IRecurringJobStorage, IDisposable
 	private static RedisValue[] CreateMaterializeArguments(
 		RecurringJobSchedule schedule,
 		JobRecord job,
-		DateTimeOffset nextRunAt
+		DateTimeOffset nextRunAt,
+		DateTimeOffset now
 	) =>
 	[
 		Ticks(schedule.NextRunAt),
@@ -859,6 +879,7 @@ public sealed class RedisJobStorage : IRecurringJobStorage, IDisposable
 		schedule.Name,
 		Ticks(job.CreatedAt),
 		job.CompletedAt is { } completedAt ? Score(completedAt) : 0,
+		Score(now),
 	];
 
 	private static void ValidateQueueJob(JobRecord job)

--- a/src/Immediate.Jobs.Redis/RedisJobStorage.cs
+++ b/src/Immediate.Jobs.Redis/RedisJobStorage.cs
@@ -542,8 +542,9 @@ public sealed class RedisJobStorage : IRecurringJobStorage, IDisposable
 			take: batchSize
 		).WaitAsync(cancellationToken).ConfigureAwait(false);
 		var members = values.Select(static value => (string)value!).ToArray();
+		var names = members.Select(static member => member[20..]).Distinct(StringComparer.Ordinal).ToArray();
 		var schedules = await ReadRecurringAsync(
-			[.. members.Select(static member => member[20..])],
+			names,
 			cancellationToken
 		).ConfigureAwait(false);
 		var schedulesByName = schedules.ToDictionary(static schedule => schedule.Name, StringComparer.Ordinal);

--- a/src/Immediate.Jobs.Redis/RedisJobStorage.cs
+++ b/src/Immediate.Jobs.Redis/RedisJobStorage.cs
@@ -392,7 +392,7 @@ public sealed class RedisJobStorage : IRecurringJobStorage, IDisposable
 		ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
 		var result = await EvaluateInt64Async(
 			RedisScripts.Delete,
-			[JobKey(jobId), AllJobsKey],
+			[JobKey(jobId), AllJobsKey, RecurringDedupeKey],
 			[jobId, _root],
 			cancellationToken
 		).ConfigureAwait(false);
@@ -667,7 +667,7 @@ public sealed class RedisJobStorage : IRecurringJobStorage, IDisposable
 				var id = (string)value!;
 				_ = await EvaluateInt64Async(
 					RedisScripts.Purge,
-					[JobKey(id), CompletedKey(state), AllJobsKey, StateKey(state)],
+					[JobKey(id), CompletedKey(state), AllJobsKey, StateKey(state), RecurringDedupeKey],
 					[id, (int)state],
 					cancellationToken
 				).ConfigureAwait(false);

--- a/src/Immediate.Jobs.Redis/RedisScripts.cs
+++ b/src/Immediate.Jobs.Redis/RedisScripts.cs
@@ -206,12 +206,14 @@ internal static class RedisScripts
 	internal const string Delete =
 		"""
 		if redis.call('EXISTS', KEYS[1]) == 0 then return 0 end
-		local state = redis.call('HGET', KEYS[1], 'state')
+		local values = redis.call('HMGET', KEYS[1], 'state', 'recurringKey')
+		local state = values[1]
 		if state ~= '5' and state ~= '6' and state ~= '7' then return -1 end
 		redis.call('DEL', KEYS[1])
 		redis.call('ZREM', KEYS[2], ARGV[1])
 		redis.call('SREM', ARGV[2] .. 'state:' .. state, ARGV[1])
 		redis.call('ZREM', ARGV[2] .. 'completed:' .. state, ARGV[1])
+		if values[2] and values[2] ~= '' then redis.call('HDEL', KEYS[3], values[2]) end
 		return 1
 		""";
 
@@ -221,7 +223,7 @@ internal static class RedisScripts
 			redis.call('ZREM', KEYS[2], ARGV[1])
 			return 0
 		end
-		local values = redis.call('HMGET', KEYS[1], 'state', 'completed')
+		local values = redis.call('HMGET', KEYS[1], 'state', 'completed', 'recurringKey')
 		if values[1] ~= ARGV[2] then
 			redis.call('ZREM', KEYS[2], ARGV[1])
 			return 0
@@ -230,6 +232,7 @@ internal static class RedisScripts
 		redis.call('ZREM', KEYS[2], ARGV[1])
 		redis.call('ZREM', KEYS[3], ARGV[1])
 		redis.call('SREM', KEYS[4], ARGV[1])
+		if values[3] and values[3] ~= '' then redis.call('HDEL', KEYS[5], values[3]) end
 		return 1
 		""";
 
@@ -313,7 +316,6 @@ internal static class RedisScripts
 		if ARGV[2] ~= '' then
 			inserted = redis.call('HSETNX', KEYS[2], ARGV[2], ARGV[3])
 		end
-		if inserted == 0 then return 0 end
 		if inserted == 1 then
 			if redis.call('EXISTS', KEYS[3]) == 1 then
 				if ARGV[2] ~= '' then redis.call('HDEL', KEYS[2], ARGV[2]) end
@@ -322,6 +324,7 @@ internal static class RedisScripts
 			redis.call('HSET', KEYS[3],
 				'record', ARGV[4], 'state', ARGV[5], 'due', ARGV[6], 'dueScore', ARGV[7],
 				'created', ARGV[22], 'dueMember', ARGV[6] .. '|' .. ARGV[22] .. '|' .. ARGV[3],
+				'recurringKey', ARGV[2],
 				'attempt', ARGV[8], 'worker', ARGV[9], 'lease', ARGV[10],
 				'error', ARGV[11], 'completed', ARGV[12],
 				'executionTraceId', ARGV[13], 'executionSpanId', ARGV[14],

--- a/src/Immediate.Jobs.Redis/RedisScripts.cs
+++ b/src/Immediate.Jobs.Redis/RedisScripts.cs
@@ -247,7 +247,7 @@ internal static class RedisScripts
 		end
 		redis.call('HSET', KEYS[1],
 			'record', ARGV[1], 'code', ARGV[2], 'paused', paused,
-			'next', ARGV[4], 'last', last, 'dueMember', ARGV[8])
+			'next', ARGV[4], 'last', last, 'dueScore', ARGV[7], 'dueMember', ARGV[8])
 		redis.call('SADD', KEYS[2], ARGV[6])
 		if paused == '1' then
 			redis.call('ZREM', KEYS[3], ARGV[8])
@@ -291,10 +291,11 @@ internal static class RedisScripts
 		"""
 		if redis.call('EXISTS', KEYS[1]) == 0 then return 0 end
 		redis.call('HSET', KEYS[1], 'paused', ARGV[1])
+		local due = redis.call('HMGET', KEYS[1], 'dueScore', 'dueMember')
 		if ARGV[1] == '1' then
-			redis.call('ZREM', KEYS[2], ARGV[4])
-		else
-			redis.call('ZADD', KEYS[2], ARGV[3], ARGV[4])
+			if due[2] then redis.call('ZREM', KEYS[2], due[2]) end
+		elseif due[1] and due[2] then
+			redis.call('ZADD', KEYS[2], due[1], due[2])
 		end
 		return 1
 		""";
@@ -302,9 +303,12 @@ internal static class RedisScripts
 	internal const string MaterializeRecurring =
 		"""
 		if redis.call('EXISTS', KEYS[1]) == 0 then return 0 end
-		if redis.call('HGET', KEYS[1], 'next') ~= ARGV[1] then return 0 end
-		if redis.call('HGET', KEYS[1], 'paused') == '1' then return 0 end
-		local previousDueMember = redis.call('HGET', KEYS[1], 'dueMember')
+		local schedule = redis.call('HMGET', KEYS[1], 'next', 'paused', 'dueMember')
+		if schedule[1] ~= ARGV[1] or schedule[2] == '1' then return 0 end
+		local previousDueMember = schedule[3]
+		if not previousDueMember or previousDueMember ~= ARGV[1] .. '|' .. ARGV[21] then return 0 end
+		local previousDueScore = redis.call('ZSCORE', KEYS[7], previousDueMember)
+		if not previousDueScore or tonumber(previousDueScore) > tonumber(ARGV[24]) then return 0 end
 		local inserted = 1
 		if ARGV[2] ~= '' then
 			inserted = redis.call('HSETNX', KEYS[2], ARGV[2], ARGV[3])
@@ -332,7 +336,7 @@ internal static class RedisScripts
 		end
 		local nextDueMember = ARGV[19] .. '|' .. ARGV[21]
 		redis.call('HSET', KEYS[1],
-			'last', ARGV[1], 'next', ARGV[19], 'dueMember', nextDueMember)
+			'last', ARGV[1], 'next', ARGV[19], 'dueScore', ARGV[20], 'dueMember', nextDueMember)
 		if previousDueMember then redis.call('ZREM', KEYS[7], previousDueMember) end
 		redis.call('ZADD', KEYS[7], ARGV[20], nextDueMember)
 		return inserted

--- a/src/Immediate.Jobs.Shared/JobSchedulerService.cs
+++ b/src/Immediate.Jobs.Shared/JobSchedulerService.cs
@@ -465,9 +465,7 @@ public sealed partial class JobSchedulerService : BackgroundService
 					.Select(definition => new
 					{
 						definition.Name,
-						Capacity = definition.MaxConcurrency == 0
-							? capacity
-							: definition.MaxConcurrency - _jobReservations.GetValueOrDefault(definition.Name),
+						Capacity = GetJobAcquisitionCapacity(definition, capacity),
 					})
 					.Where(static item => item.Capacity > 0)
 					.ToDictionary(static item => item.Name, static item => item.Capacity, StringComparer.Ordinal);
@@ -495,6 +493,14 @@ public sealed partial class JobSchedulerService : BackgroundService
 				Queues = queues,
 				FairQueues = _fairQueuePolicy,
 			};
+	}
+
+	private int GetJobAcquisitionCapacity(JobDefinition definition, int availableCapacity)
+	{
+		var limit = definition.OverlapPolicy == OverlapPolicy.Queue ? 1 : definition.MaxConcurrency;
+		return limit == 0
+			? availableCapacity
+			: limit - _jobReservations.GetValueOrDefault(definition.Name);
 	}
 
 	private void WarnIfGroupedJobsAreInert(IReadOnlyList<JobRecord> acquired)

--- a/src/Immediate.Jobs.Shared/JobSchedulerService.cs
+++ b/src/Immediate.Jobs.Shared/JobSchedulerService.cs
@@ -630,39 +630,69 @@ public sealed partial class JobSchedulerService : BackgroundService
 			if (!_definitions.TryGetValue(schedule.JobName, out var definition))
 				continue;
 
-			var expression = JobCron.Parse(schedule.Cron);
-			var next = expression.GetNextOccurrence(schedule.NextRunAt, JobCron.GetTimeZone(schedule.TimeZone))
-				?? throw new ImmediateJobException($"Recurring schedule '{schedule.Name}' has no future occurrence.");
-			var (traceParent, traceState) = TraceContextCapture.Current();
-			var record = new JobRecord
+			try
 			{
-				Id = _idGenerator.CreateId(IdKind.Job),
-				JobName = schedule.JobName,
-				QueueName = definition.Queue.Name,
-				Payload = "{}",
-				State = JobState.Pending,
-				DueAt = schedule.NextRunAt,
-				CreatedAt = now,
-				RecurringKey = string.Create(CultureInfo.InvariantCulture, $"{schedule.Name}:{schedule.NextRunAt.UtcTicks}"),
-				TraceParent = traceParent,
-				TraceState = traceState,
-			};
-
-			if (definition.OverlapPolicy == OverlapPolicy.Skip)
-			{
-				var active = await _storage.QueryJobsAsync(
-					new() { State = JobState.Active, JobName = definition.Name, Take = 1 },
+				await MaterializeRecurringScheduleAsync(
+					recurringStorage,
+					schedule,
+					definition,
+					now,
 					cancellationToken
 				).ConfigureAwait(false);
-				if (active.Count != 0)
-					record = record with { State = JobState.Cancelled, CompletedAt = now };
 			}
-
-			if (await recurringStorage.MaterializeRecurringAsync(schedule, record, next, cancellationToken).ConfigureAwait(false)
-				&& record.State == JobState.Pending)
+			catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
 			{
-				JobTelemetry.Enqueued(record.JobName, record.QueueName);
+				throw;
 			}
+#pragma warning disable CA1031 // One malformed schedule must not block unrelated schedules or job acquisition.
+			catch (Exception exception)
+#pragma warning restore CA1031
+			{
+				RecurringMaterializationFailed(_logger, exception, schedule.Name);
+			}
+		}
+	}
+
+	private async Task MaterializeRecurringScheduleAsync(
+		IRecurringJobStorage recurringStorage,
+		RecurringJobSchedule schedule,
+		JobDefinition definition,
+		DateTimeOffset now,
+		CancellationToken cancellationToken
+	)
+	{
+		var expression = JobCron.Parse(schedule.Cron);
+		var next = expression.GetNextOccurrence(schedule.NextRunAt, JobCron.GetTimeZone(schedule.TimeZone))
+			?? throw new ImmediateJobException($"Recurring schedule '{schedule.Name}' has no future occurrence.");
+		var (traceParent, traceState) = TraceContextCapture.Current();
+		var record = new JobRecord
+		{
+			Id = _idGenerator.CreateId(IdKind.Job),
+			JobName = schedule.JobName,
+			QueueName = definition.Queue.Name,
+			Payload = "{}",
+			State = JobState.Pending,
+			DueAt = schedule.NextRunAt,
+			CreatedAt = now,
+			RecurringKey = string.Create(CultureInfo.InvariantCulture, $"{schedule.Name}:{schedule.NextRunAt.UtcTicks}"),
+			TraceParent = traceParent,
+			TraceState = traceState,
+		};
+
+		if (definition.OverlapPolicy == OverlapPolicy.Skip)
+		{
+			var active = await _storage.QueryJobsAsync(
+				new() { State = JobState.Active, JobName = definition.Name, Take = 1 },
+				cancellationToken
+			).ConfigureAwait(false);
+			if (active.Count != 0)
+				record = record with { State = JobState.Cancelled, CompletedAt = now };
+		}
+
+		if (await recurringStorage.MaterializeRecurringAsync(schedule, record, next, cancellationToken).ConfigureAwait(false)
+			&& record.State == JobState.Pending)
+		{
+			JobTelemetry.Enqueued(record.JobName, record.QueueName);
 		}
 	}
 
@@ -736,6 +766,17 @@ public sealed partial class JobSchedulerService : BackgroundService
 		Message = "Could not renew the lease for job {jobId}; renewal will be retried until the attempt finishes"
 	)]
 	private static partial void LeaseRenewalFailed(ILogger logger, Exception exception, string jobId);
+
+	[LoggerMessage(
+		EventId = 11,
+		Level = LogLevel.Error,
+		Message = "Could not materialize recurring schedule {scheduleName}; other schedules and job acquisition will continue"
+	)]
+	private static partial void RecurringMaterializationFailed(
+		ILogger logger,
+		Exception exception,
+		string scheduleName
+	);
 }
 
 /// <summary>Scheduler liveness state shared with health checks and monitoring.</summary>

--- a/src/Immediate.Jobs.Shared/JobSchedulerService.cs
+++ b/src/Immediate.Jobs.Shared/JobSchedulerService.cs
@@ -691,7 +691,11 @@ public sealed partial class JobSchedulerService : BackgroundService
 				new() { State = JobState.Active, JobName = definition.Name, Take = 1 },
 				cancellationToken
 			).ConfigureAwait(false);
-			if (active.Count != 0)
+			var pending = await _storage.QueryJobsAsync(
+				new() { State = JobState.Pending, JobName = definition.Name, Take = 1 },
+				cancellationToken
+			).ConfigureAwait(false);
+			if (active.Count != 0 || pending.Count != 0)
 				record = record with { State = JobState.Cancelled, CompletedAt = now };
 		}
 

--- a/src/Immediate.Jobs.Shared/JobSchedulers.cs
+++ b/src/Immediate.Jobs.Shared/JobSchedulers.cs
@@ -515,11 +515,22 @@ internal static class JobCron
 	public static CronExpression Parse(string cron)
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(cron);
-		var fields = cron.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
+		var normalized = cron.Trim().ToUpperInvariant() switch
+		{
+			"@YEARLY" or "@ANNUALLY" => "0 0 1 1 *",
+			"@MONTHLY" => "0 0 1 * *",
+			"@WEEKLY" => "0 0 * * 0",
+			"@DAILY" or "@MIDNIGHT" => "0 0 * * *",
+			"@HOURLY" => "0 * * * *",
+			"@EVERY_MINUTE" => "* * * * *",
+			"@EVERY_SECOND" => "* * * * * *",
+			_ => string.Join(' ', cron.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)),
+		};
+		var fields = normalized.Split(' ').Length;
 		if (fields is not (5 or 6))
 			throw new CronFormatException("A cron expression must contain five or six fields.");
 
-		return CronExpression.Parse(cron, fields == 6 ? CronFormat.IncludeSeconds : CronFormat.Standard);
+		return CronExpression.Parse(normalized, fields == 6 ? CronFormat.IncludeSeconds : CronFormat.Standard);
 	}
 
 	public static TimeZoneInfo GetTimeZone(string timeZone)

--- a/tests/Immediate.Jobs.FunctionalTests/RecurringSchedulerTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/RecurringSchedulerTests.cs
@@ -49,6 +49,31 @@ public sealed class RecurringSchedulerTests
 	}
 
 	[Fact]
+	public async Task OverlapQueueAcquiresOneInvocationAtATime()
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		var clock = new FakeTimeProvider(Start);
+		await using var storage = new InMemoryJobStorage(clock);
+		await storage.InitializeAsync(cancellationToken);
+		await AddPendingRecurringJob(storage, "queued", "queue:1", Start, cancellationToken);
+		await AddPendingRecurringJob(storage, "queued", "queue:2", Start, cancellationToken);
+		var invoker = new AssertNoOverlapInvoker(storage);
+		var scheduler = BuildScheduler(
+			storage,
+			clock,
+			"queued",
+			cron: null,
+			invoker,
+			OverlapPolicy.Queue,
+			maxParallelJobs: 2
+		);
+
+		await scheduler.DrainAsync(cancellationToken);
+
+		Assert.Equal(2, invoker.Executions);
+	}
+
+	[Fact]
 	public async Task RestartKeepsAnOccurrenceThatFellDuringDowntime()
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;
@@ -176,27 +201,49 @@ public sealed class RecurringSchedulerTests
 		LeaseExpiresAt = clock.GetUtcNow().AddMinutes(30),
 	}, cancellationToken);
 
+	private static ValueTask AddPendingRecurringJob(
+		InMemoryJobStorage storage,
+		string jobName,
+		string recurringKey,
+		DateTimeOffset dueAt,
+		CancellationToken cancellationToken
+	) => storage.EnqueueAsync(new()
+	{
+		Id = Guid.NewGuid().ToString("N"),
+		JobName = jobName,
+		Payload = "{}",
+		State = JobState.Pending,
+		DueAt = dueAt,
+		CreatedAt = dueAt,
+		RecurringKey = recurringKey,
+	}, cancellationToken);
+
 	private static JobSchedulerService BuildScheduler(
 		InMemoryJobStorage storage,
 		TimeProvider clock,
 		string jobName,
-		string? cron
+		string? cron,
+		IJobInvoker? invoker = null,
+		OverlapPolicy overlapPolicy = OverlapPolicy.Skip,
+		int maxParallelJobs = 1
 	)
 	{
+		invoker ??= NoOpInvoker.Instance;
 		var services = new ServiceCollection();
 		_ = services.AddLogging();
 		_ = services.AddSingleton(clock);
 		_ = services.AddImmediateJobsCore(options =>
 		{
 			_ = options.UseStorage(_ => storage).UseDistributed();
-			options.MaxParallelJobs = 1;
+			options.MaxParallelJobs = maxParallelJobs;
 		});
 		_ = services.AddSingleton(new JobDefinition
 		{
 			Name = jobName,
 			Cron = cron,
-			Invoker = NoOpInvoker.Instance,
-			JobType = typeof(NoOpInvoker),
+			Invoker = invoker,
+			JobType = invoker.GetType(),
+			OverlapPolicy = overlapPolicy,
 		});
 
 		var provider = services.BuildServiceProvider();
@@ -209,6 +256,21 @@ public sealed class RecurringSchedulerTests
 
 		public ValueTask InvokeAsync(IServiceProvider scopedServices, JobExecution execution) =>
 			ValueTask.CompletedTask;
+	}
+
+	private sealed class AssertNoOverlapInvoker(InMemoryJobStorage storage) : IJobInvoker
+	{
+		public int Executions { get; private set; }
+
+		public async ValueTask InvokeAsync(IServiceProvider scopedServices, JobExecution execution)
+		{
+			var active = await storage.QueryJobsAsync(
+				new() { State = JobState.Active, JobName = execution.Record.JobName, Take = 100 },
+				execution.CancellationToken
+			);
+			_ = Assert.Single(active);
+			Executions++;
+		}
 	}
 }
 #pragma warning restore CS1591

--- a/tests/Immediate.Jobs.FunctionalTests/RecurringSchedulerTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/RecurringSchedulerTests.cs
@@ -49,6 +49,28 @@ public sealed class RecurringSchedulerTests
 	}
 
 	[Fact]
+	public async Task OverlapSkipDetectsAPendingOccurrence()
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		var clock = new FakeTimeProvider(Start);
+		await using var storage = new InMemoryJobStorage(clock);
+		await storage.InitializeAsync(cancellationToken);
+		await AddPendingRecurringJob(storage, "cleanup", "cleanup:future", Start.AddHours(2), cancellationToken);
+
+		var scheduler = BuildScheduler(storage, clock, "cleanup", "0 * * * *");
+		await scheduler.DrainAsync(cancellationToken);
+		clock.SetUtcNow(Start.AddHours(1));
+		await scheduler.DrainAsync(cancellationToken);
+
+		var jobs = await storage.QueryJobsAsync(
+			new() { JobName = "cleanup", Take = 100 },
+			cancellationToken
+		);
+		var occurrence = Assert.Single(jobs, job => job.DueAt == Start.AddHours(1));
+		Assert.Equal(JobState.Cancelled, occurrence.State);
+	}
+
+	[Fact]
 	public async Task OverlapQueueAcquiresOneInvocationAtATime()
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;
@@ -65,7 +87,8 @@ public sealed class RecurringSchedulerTests
 			cron: null,
 			invoker,
 			OverlapPolicy.Queue,
-			maxParallelJobs: 2
+			maxParallelJobs: 2,
+			maxAttempts: 1
 		);
 
 		await scheduler.DrainAsync(cancellationToken);
@@ -225,7 +248,8 @@ public sealed class RecurringSchedulerTests
 		string? cron,
 		IJobInvoker? invoker = null,
 		OverlapPolicy overlapPolicy = OverlapPolicy.Skip,
-		int maxParallelJobs = 1
+		int maxParallelJobs = 1,
+		int maxAttempts = 3
 	)
 	{
 		invoker ??= NoOpInvoker.Instance;
@@ -244,6 +268,7 @@ public sealed class RecurringSchedulerTests
 			Invoker = invoker,
 			JobType = invoker.GetType(),
 			OverlapPolicy = overlapPolicy,
+			MaxAttempts = maxAttempts,
 		});
 
 		var provider = services.BuildServiceProvider();

--- a/tests/Immediate.Jobs.FunctionalTests/RecurringSchedulerTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/RecurringSchedulerTests.cs
@@ -79,6 +79,44 @@ public sealed class RecurringSchedulerTests
 		);
 	}
 
+	[Theory]
+	[InlineData("not-a-cron", "UTC")]
+	[InlineData("* * * * *", "Missing/TimeZone")]
+	public async Task BadRecurringScheduleDoesNotBlockOrdinaryJobs(string cron, string timeZone)
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		var clock = new FakeTimeProvider(Start);
+		await using var storage = new InMemoryJobStorage(clock);
+		await storage.InitializeAsync(cancellationToken);
+		await storage.UpsertRecurringAsync(new()
+		{
+			Name = "bad-schedule",
+			JobName = "ordinary",
+			Cron = cron,
+			TimeZone = timeZone,
+			IsCodeDefined = false,
+			NextRunAt = Start,
+		}, cancellationToken);
+		await storage.EnqueueAsync(new()
+		{
+			Id = "ordinary-job",
+			JobName = "ordinary",
+			Payload = "{}",
+			State = JobState.Pending,
+			DueAt = Start,
+			CreatedAt = Start,
+		}, cancellationToken);
+		var scheduler = BuildScheduler(storage, clock, "ordinary", cron: null);
+
+		await scheduler.DrainAsync(cancellationToken);
+
+		Assert.Equal(
+			JobState.Succeeded,
+			(await storage.GetJobStatusAsync("ordinary-job", cancellationToken))!.State
+		);
+		Assert.Equal(Start, (await GetSchedule(storage, "bad-schedule", cancellationToken)).NextRunAt);
+	}
+
 	private static async ValueTask<RecurringJobSchedule> GetSchedule(
 		InMemoryJobStorage storage,
 		string name,
@@ -111,7 +149,7 @@ public sealed class RecurringSchedulerTests
 		InMemoryJobStorage storage,
 		TimeProvider clock,
 		string jobName,
-		string cron
+		string? cron
 	)
 	{
 		var services = new ServiceCollection();

--- a/tests/Immediate.Jobs.FunctionalTests/RecurringSchedulerTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/RecurringSchedulerTests.cs
@@ -7,6 +7,19 @@ namespace Immediate.Jobs.FunctionalTests;
 public sealed class RecurringSchedulerTests
 {
 	private static readonly DateTimeOffset Start = new(2026, 1, 1, 10, 0, 0, TimeSpan.Zero);
+	public static TheoryData<string, DateTimeOffset> RuntimeCronForms => new()
+	{
+		{ "@yearly", new(2027, 1, 1, 0, 0, 0, TimeSpan.Zero) },
+		{ "@annually", new(2027, 1, 1, 0, 0, 0, TimeSpan.Zero) },
+		{ "@monthly", new(2026, 2, 1, 0, 0, 0, TimeSpan.Zero) },
+		{ "@weekly", new(2026, 1, 4, 0, 0, 0, TimeSpan.Zero) },
+		{ "@DAILY", new(2026, 1, 2, 0, 0, 0, TimeSpan.Zero) },
+		{ "@midnight", new(2026, 1, 2, 0, 0, 0, TimeSpan.Zero) },
+		{ "@hourly", new(2026, 1, 1, 11, 0, 0, TimeSpan.Zero) },
+		{ "@every_minute", new(2026, 1, 1, 10, 1, 0, TimeSpan.Zero) },
+		{ "@every_second", new(2026, 1, 1, 10, 0, 1, TimeSpan.Zero) },
+		{ "0\t*\t*\t*\t*", new(2026, 1, 1, 11, 0, 0, TimeSpan.Zero) },
+	};
 
 	[Fact]
 	public async Task OverlapSkipDetectsAnActiveRunHiddenBehindALongerJobName()
@@ -76,6 +89,24 @@ public sealed class RecurringSchedulerTests
 		Assert.Equal(
 			new DateTimeOffset(2026, 1, 2, 0, 0, 0, TimeSpan.Zero),
 			(await GetSchedule(storage, "shifting", cancellationToken)).NextRunAt
+		);
+	}
+
+	[Theory]
+	[MemberData(nameof(RuntimeCronForms))]
+	public async Task RuntimeAcceptsAnalyzerCronForms(string cron, DateTimeOffset expectedNextRunAt)
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		var clock = new FakeTimeProvider(Start);
+		await using var storage = new InMemoryJobStorage(clock);
+		await storage.InitializeAsync(cancellationToken);
+		var scheduler = BuildScheduler(storage, clock, "analyzer-compatible", cron);
+
+		await scheduler.DrainAsync(cancellationToken);
+
+		Assert.Equal(
+			expectedNextRunAt,
+			(await GetSchedule(storage, "analyzer-compatible", cancellationToken)).NextRunAt
 		);
 	}
 

--- a/tests/Immediate.Jobs.StorageTests/RedisStorageTests.cs
+++ b/tests/Immediate.Jobs.StorageTests/RedisStorageTests.cs
@@ -366,6 +366,127 @@ public sealed class RedisStorageTests(RedisStorageFixture fixture)
 	}
 
 	[Fact]
+	public async Task StaleRecurringDueMemberDoesNotMaterializeFutureOccurrence()
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var connection = await ConnectionMultiplexer.ConnectAsync(fixture.Container.GetConnectionString());
+		var timeProvider = CreateTimeProvider();
+		var options = CreateOptions();
+		using var storage = new RedisJobStorage(connection, options, timeProvider);
+		var now = timeProvider.GetUtcNow();
+		var schedule = new RecurringJobSchedule
+		{
+			Name = "stale-due",
+			JobName = "test-job",
+			Cron = "0 * * * *",
+			TimeZone = "UTC",
+			IsCodeDefined = true,
+			NextRunAt = now,
+		};
+		await storage.UpsertRecurringAsync(schedule, cancellationToken);
+		Assert.True(await storage.MaterializeRecurringAsync(
+			schedule,
+			CreateJob("first-occurrence", now) with
+			{
+				RecurringKey = string.Create(CultureInfo.InvariantCulture, $"{schedule.Name}:{now.UtcTicks}"),
+			},
+			now.AddHours(1),
+			cancellationToken
+		));
+		var database = connection.GetDatabase(options.Database);
+		_ = await database.SortedSetAddAsync(
+			RecurringDueKey(options),
+			RecurringDueMember(now, schedule.Name),
+			now.ToUnixTimeMilliseconds()
+		);
+		var persisted = Assert.Single((await storage.GetMonitoringSnapshotAsync(cancellationToken)).Recurring);
+
+		Assert.False(await storage.MaterializeRecurringAsync(
+			persisted,
+			CreateJob("future-occurrence", persisted.NextRunAt) with
+			{
+				RecurringKey = string.Create(
+					CultureInfo.InvariantCulture,
+					$"{schedule.Name}:{persisted.NextRunAt.UtcTicks}"
+				),
+			},
+			persisted.NextRunAt.AddHours(1),
+			cancellationToken
+		));
+		Assert.Empty(await storage.GetDueRecurringAsync(now, 10, cancellationToken));
+
+		var member = Assert.Single(await database.SortedSetRangeByRankAsync(RecurringDueKey(options)));
+		Assert.Equal(RecurringDueMember(now.AddHours(1), schedule.Name), (string)member!);
+		Assert.Null(await storage.GetJobStatusAsync("future-occurrence", cancellationToken));
+	}
+
+	[Fact]
+	public async Task PauseResumeRaceKeepsOnlyTheCurrentDueMember()
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var connection = await ConnectionMultiplexer.ConnectAsync(fixture.Container.GetConnectionString());
+		var timeProvider = CreateTimeProvider();
+		var options = CreateOptions();
+		using var storage = new RedisJobStorage(connection, options, timeProvider);
+		var database = connection.GetDatabase(options.Database);
+		var now = timeProvider.GetUtcNow();
+		for (var index = 0; index < 20; index++)
+		{
+			var schedule = new RecurringJobSchedule
+			{
+				Name = string.Create(CultureInfo.InvariantCulture, $"pause-race-{index}"),
+				JobName = "test-job",
+				Cron = "0 * * * *",
+				TimeZone = "UTC",
+				IsCodeDefined = true,
+				NextRunAt = now,
+			};
+			await storage.UpsertRecurringAsync(schedule, cancellationToken);
+			var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+			var materialize = Task.Run(async () =>
+			{
+				await start.Task;
+				_ = await storage.MaterializeRecurringAsync(
+					schedule,
+					CreateJob(string.Create(CultureInfo.InvariantCulture, $"pause-race-job-{index}"), now) with
+					{
+						RecurringKey = string.Create(
+							CultureInfo.InvariantCulture,
+							$"{schedule.Name}:{now.UtcTicks}"
+						),
+					},
+					now.AddHours(1),
+					cancellationToken
+				);
+			}, cancellationToken);
+			var pause = Task.Run(async () =>
+			{
+				await start.Task;
+				await storage.PauseRecurringAsync(schedule.Name, cancellationToken);
+			}, cancellationToken);
+			var resume = Task.Run(async () =>
+			{
+				await start.Task;
+				await storage.ResumeRecurringAsync(schedule.Name, cancellationToken);
+			}, cancellationToken);
+
+			start.SetResult();
+			await Task.WhenAll(materialize, pause, resume);
+
+			var persisted = (await storage.GetMonitoringSnapshotAsync(cancellationToken)).Recurring
+				.Single(item => string.Equals(item.Name, schedule.Name, StringComparison.Ordinal));
+			var members = (await database.SortedSetRangeByRankAsync(RecurringDueKey(options)))
+				.Select(static member => (string)member!)
+				.Where(member => member.EndsWith($"|{schedule.Name}", StringComparison.Ordinal))
+				.ToArray();
+			if (persisted.IsPaused)
+				Assert.Empty(members);
+			else
+				Assert.Equal(RecurringDueMember(persisted.NextRunAt, schedule.Name), Assert.Single(members));
+		}
+	}
+
+	[Fact]
 	public async Task RecurringMaterializationPersistsSkippedOccurrenceAsCancelled()
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;
@@ -455,6 +576,12 @@ public sealed class RedisStorageTests(RedisStorageFixture fixture)
 
 	private static RedisKey ServerKey(RedisJobStorageOptions options, string workerId) =>
 		$"{{{options.KeyPrefix}}}:server:{workerId}";
+
+	private static RedisKey RecurringDueKey(RedisJobStorageOptions options) =>
+		$"{{{options.KeyPrefix}}}:recurring:due";
+
+	private static string RecurringDueMember(DateTimeOffset nextRunAt, string name) =>
+		string.Create(CultureInfo.InvariantCulture, $"{nextRunAt.UtcTicks:D19}|{name}");
 
 	private static JobRecord CreateJob(string id, DateTimeOffset now) => new()
 	{

--- a/tests/Immediate.Jobs.StorageTests/RedisStorageTests.cs
+++ b/tests/Immediate.Jobs.StorageTests/RedisStorageTests.cs
@@ -487,6 +487,87 @@ public sealed class RedisStorageTests(RedisStorageFixture fixture)
 	}
 
 	[Fact]
+	public async Task RecurringDedupeHitAdvancesScheduleWithoutDuplicateJob()
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var connection = await ConnectionMultiplexer.ConnectAsync(fixture.Container.GetConnectionString());
+		var timeProvider = CreateTimeProvider();
+		using var storage = new RedisJobStorage(connection, CreateOptions(), timeProvider);
+		var now = timeProvider.GetUtcNow();
+		var schedule = new RecurringJobSchedule
+		{
+			Name = "dedupe-advance",
+			JobName = "test-job",
+			Cron = "0 * * * *",
+			TimeZone = "UTC",
+			IsCodeDefined = true,
+			NextRunAt = now,
+		};
+		var recurringKey = string.Create(CultureInfo.InvariantCulture, $"{schedule.Name}:{now.UtcTicks}");
+		await storage.UpsertRecurringAsync(schedule, cancellationToken);
+		Assert.True(await storage.MaterializeRecurringAsync(
+			schedule,
+			CreateJob("dedupe-original", now) with { RecurringKey = recurringKey },
+			now.AddHours(1),
+			cancellationToken
+		));
+		await storage.UpsertRecurringAsync(schedule, cancellationToken);
+
+		Assert.False(await storage.MaterializeRecurringAsync(
+			schedule,
+			CreateJob("dedupe-duplicate", now) with { RecurringKey = recurringKey },
+			now.AddHours(1),
+			cancellationToken
+		));
+
+		var persisted = Assert.Single((await storage.GetMonitoringSnapshotAsync(cancellationToken)).Recurring);
+		Assert.Equal(now, persisted.LastRunAt);
+		Assert.Equal(now.AddHours(1), persisted.NextRunAt);
+		Assert.Null(await storage.GetJobStatusAsync("dedupe-duplicate", cancellationToken));
+		_ = Assert.Single(await storage.QueryJobsAsync(new() { Search = "test-job" }, cancellationToken));
+	}
+
+	[Fact]
+	public async Task PurgingRecurringJobRemovesItsDedupeEntry()
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var connection = await ConnectionMultiplexer.ConnectAsync(fixture.Container.GetConnectionString());
+		var timeProvider = CreateTimeProvider();
+		var options = CreateOptions();
+		using var storage = new RedisJobStorage(connection, options, timeProvider);
+		var now = timeProvider.GetUtcNow();
+		var schedule = new RecurringJobSchedule
+		{
+			Name = "dedupe-purge",
+			JobName = "test-job",
+			Cron = "0 * * * *",
+			TimeZone = "UTC",
+			IsCodeDefined = true,
+			NextRunAt = now,
+		};
+		await storage.UpsertRecurringAsync(schedule, cancellationToken);
+		Assert.True(await storage.MaterializeRecurringAsync(
+			schedule,
+			CreateJob("purged-occurrence", now) with
+			{
+				RecurringKey = string.Create(CultureInfo.InvariantCulture, $"{schedule.Name}:{now.UtcTicks}"),
+			},
+			now.AddHours(1),
+			cancellationToken
+		));
+		_ = Assert.Single(await storage.AcquireDueJobsAsync(CreateRequest("worker", 1), cancellationToken));
+		await storage.CompleteAsync("purged-occurrence", "worker", cancellationToken);
+		var database = connection.GetDatabase(options.Database);
+		Assert.Equal(1, await database.HashLengthAsync(RecurringDedupeKey(options)));
+		timeProvider.Advance(TimeSpan.FromMilliseconds(1));
+
+		await storage.PurgeJobsAsync(TimeSpan.Zero, TimeSpan.Zero, cancellationToken);
+
+		Assert.Equal(0, await database.HashLengthAsync(RecurringDedupeKey(options)));
+		Assert.Null(await storage.GetJobStatusAsync("purged-occurrence", cancellationToken));
+	}
+
+	[Fact]
 	public async Task RecurringMaterializationPersistsSkippedOccurrenceAsCancelled()
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;
@@ -579,6 +660,9 @@ public sealed class RedisStorageTests(RedisStorageFixture fixture)
 
 	private static RedisKey RecurringDueKey(RedisJobStorageOptions options) =>
 		$"{{{options.KeyPrefix}}}:recurring:due";
+
+	private static RedisKey RecurringDedupeKey(RedisJobStorageOptions options) =>
+		$"{{{options.KeyPrefix}}}:recurring:dedupe";
 
 	private static string RecurringDueMember(DateTimeOffset nextRunAt, string name) =>
 		string.Create(CultureInfo.InvariantCulture, $"{nextRunAt.UtcTicks:D19}|{name}");

--- a/tests/Immediate.Jobs.StorageTests/RedisStorageTests.cs
+++ b/tests/Immediate.Jobs.StorageTests/RedisStorageTests.cs
@@ -421,6 +421,40 @@ public sealed class RedisStorageTests(RedisStorageFixture fixture)
 	}
 
 	[Fact]
+	public async Task DuplicateRecurringDueMembersForSameScheduleAreDeduplicated()
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var connection = await ConnectionMultiplexer.ConnectAsync(fixture.Container.GetConnectionString());
+		var timeProvider = CreateTimeProvider();
+		var options = CreateOptions();
+		using var storage = new RedisJobStorage(connection, options, timeProvider);
+		var now = timeProvider.GetUtcNow();
+		var dueAt = now.AddHours(1);
+		var schedule = new RecurringJobSchedule
+		{
+			Name = "duplicate-due",
+			JobName = "test-job",
+			Cron = "0 * * * *",
+			TimeZone = "UTC",
+			IsCodeDefined = true,
+			NextRunAt = dueAt,
+		};
+		await storage.UpsertRecurringAsync(schedule, cancellationToken);
+		var database = connection.GetDatabase(options.Database);
+		_ = await database.SortedSetAddAsync(
+			RecurringDueKey(options),
+			RecurringDueMember(now, schedule.Name),
+			now.ToUnixTimeMilliseconds()
+		);
+
+		var due = Assert.Single(await storage.GetDueRecurringAsync(dueAt, 10, cancellationToken));
+
+		Assert.Equal(dueAt, due.NextRunAt);
+		var member = Assert.Single(await database.SortedSetRangeByRankAsync(RecurringDueKey(options)));
+		Assert.Equal(RecurringDueMember(dueAt, schedule.Name), (string)member!);
+	}
+
+	[Fact]
 	public async Task PauseResumeRaceKeepsOnlyTheCurrentDueMember()
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;

--- a/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
+++ b/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
@@ -168,6 +168,43 @@ public sealed class RelationalStorageMatrixTests(StorageContainers containers)
 
 	[Theory]
 	[MemberData(nameof(Matrix))]
+	public async Task ReclaimedLeaseRejectsStaleCompletionAndItsBufferedContinuation(
+		DatabaseKind database,
+		AdapterKind adapter
+	)
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var fixture = await CreateFixtureAsync(database, adapter, cancellationToken);
+		var first = fixture.CreateStorage();
+		var second = fixture.CreateStorage();
+		var firstGraph = Assert.IsAssignableFrom<IJobGraphStorage>(first);
+		var now = fixture.TimeProvider.GetUtcNow();
+		await first.EnqueueAsync(CreateJob("reclaimed-parent", now), cancellationToken);
+		_ = Assert.Single(await first.AcquireDueJobsAsync(CreateRequest("node-a", 1), cancellationToken));
+		fixture.TimeProvider.Advance(TimeSpan.FromMinutes(2));
+		var reclaimed = Assert.Single(await second.AcquireDueJobsAsync(CreateRequest("node-b", 1), cancellationToken));
+
+		var exception = await Assert.ThrowsAsync<ImmediateJobException>(() =>
+			firstGraph.CompleteWithContinuationsAsync(
+				"reclaimed-parent",
+				"node-a",
+				[new()
+				{
+					Job = CreateJob("stale-continuation", fixture.TimeProvider.GetUtcNow()),
+					Options = ContinuationOptions.Detached,
+				}],
+				cancellationToken
+			).AsTask()
+		);
+
+		Assert.Contains("does not own active job", exception.Message, StringComparison.Ordinal);
+		Assert.Empty(await first.QueryJobsAsync(new() { Id = "stale-continuation" }, cancellationToken));
+		Assert.Equal("node-b", reclaimed.WorkerId);
+		Assert.Equal(JobState.Active, (await first.GetJobStatusAsync("reclaimed-parent", cancellationToken))!.State);
+	}
+
+	[Theory]
+	[MemberData(nameof(Matrix))]
 	public async Task AdapterPagesJobsWithTiedCreationTimesExactlyOnce(DatabaseKind database, AdapterKind adapter)
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;

--- a/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
+++ b/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
@@ -596,6 +596,55 @@ public sealed class RelationalStorageMatrixTests(StorageContainers containers)
 
 	[Theory]
 	[MemberData(nameof(Matrix))]
+	public async Task ConcurrentCompletionAndContinuationInsertCannotStrandChild(
+		DatabaseKind database,
+		AdapterKind adapter
+	)
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var fixture = await CreateFixtureAsync(database, adapter, cancellationToken);
+		var storage = fixture.GraphStorage;
+		var replica = Assert.IsAssignableFrom<IJobStorageReplica>(storage);
+		var now = fixture.TimeProvider.GetUtcNow();
+		for (var index = 0; index < 20; index++)
+		{
+			var parentId = string.Create(CultureInfo.InvariantCulture, $"racing-parent-{index}");
+			var childId = string.Create(CultureInfo.InvariantCulture, $"racing-child-{index}");
+			var parent = CreateJob(parentId, now.AddTicks(index * 2)) with { DueAt = now };
+			var child = CreateJob(childId, now.AddTicks(index * 2 + 1)) with { DueAt = now };
+			await storage.EnqueueAsync(parent, cancellationToken);
+			_ = Assert.Single(await replica.AcquireJobsAsync(
+				[parent.Id],
+				"worker",
+				TimeSpan.FromMinutes(1),
+				cancellationToken
+			));
+			var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+			var completion = Task.Run(async () =>
+			{
+				await start.Task;
+				await storage.CompleteAsync(parent.Id, "worker", cancellationToken);
+			}, cancellationToken);
+			var insertion = Task.Run(async () =>
+			{
+				await start.Task;
+				await storage.EnqueueContinuationAsync(child, [new()
+				{
+					ChildJobId = child.Id,
+					ParentJobId = parent.Id,
+					Trigger = ContinuationTrigger.Complete,
+				}], cancellationToken);
+			}, cancellationToken);
+
+			start.SetResult();
+			await Task.WhenAll(completion, insertion);
+
+			Assert.Equal(JobState.Pending, (await storage.GetJobStatusAsync(child.Id, cancellationToken))!.State);
+		}
+	}
+
+	[Theory]
+	[MemberData(nameof(Matrix))]
 	public async Task DynamicAdditionsRejectInvalidBatchIdsBeforeMutation(
 		DatabaseKind database,
 		AdapterKind adapter

--- a/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
+++ b/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
@@ -261,6 +261,77 @@ public sealed class RelationalStorageMatrixTests(StorageContainers containers)
 	}
 
 	[Theory]
+	[MemberData(nameof(LinqToDbDatabases))]
+	public async Task LinqRecurringUpsertSurvivesConcurrentMaterialization(DatabaseKind database)
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var fixture = await CreateFixtureAsync(
+			database,
+			AdapterKind.LinqToDB,
+			cancellationToken
+		);
+		var storage = fixture.RecurringStorage;
+		var now = fixture.TimeProvider.GetUtcNow();
+		var schedule = new RecurringJobSchedule
+		{
+			Name = "racing-upsert",
+			JobName = "matrix-test",
+			Cron = "0 * * * *",
+			TimeZone = "UTC",
+			IsCodeDefined = false,
+			NextRunAt = now,
+		};
+		await storage.UpsertRecurringAsync(schedule, cancellationToken);
+
+		for (var iteration = 0; iteration < 20; iteration++)
+		{
+			var current = Assert.Single((await storage.GetMonitoringSnapshotAsync(cancellationToken)).Recurring);
+			var requested = schedule with
+			{
+				Cron = iteration % 2 == 0 ? "15 * * * *" : "45 * * * *",
+				NextRunAt = now.AddDays(iteration + 1),
+			};
+			var occurrence = CreateJob(
+				string.Create(CultureInfo.InvariantCulture, $"racing-occurrence-{iteration}"),
+				now
+			) with
+			{
+				RecurringKey = string.Create(
+					CultureInfo.InvariantCulture,
+					$"racing-upsert:{current.NextRunAt.UtcTicks}"
+				),
+			};
+			var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+			async Task MaterializeAsync()
+			{
+				await start.Task;
+				_ = await storage.MaterializeRecurringAsync(
+					current,
+					occurrence,
+					current.NextRunAt.AddMinutes(1),
+					cancellationToken
+				);
+			}
+
+			async Task UpsertAsync()
+			{
+				await start.Task;
+				await storage.UpsertRecurringAsync(requested, cancellationToken);
+			}
+
+			var materialization = MaterializeAsync();
+			var upsert = UpsertAsync();
+
+			start.SetResult();
+			await Task.WhenAll(materialization, upsert);
+
+			var persisted = Assert.Single((await storage.GetMonitoringSnapshotAsync(cancellationToken)).Recurring);
+			Assert.Equal(requested.Cron, persisted.Cron);
+			Assert.Equal(requested.NextRunAt, persisted.NextRunAt);
+		}
+	}
+
+	[Theory]
 	[MemberData(nameof(Matrix))]
 	public async Task AdapterPagesJobsWithTiedCreationTimesExactlyOnce(DatabaseKind database, AdapterKind adapter)
 	{

--- a/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
+++ b/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
@@ -533,6 +533,69 @@ public sealed class RelationalStorageMatrixTests(StorageContainers containers)
 
 	[Theory]
 	[MemberData(nameof(Matrix))]
+	public async Task RetriedParentDoesNotSettleContinuationEdgeTwice(
+		DatabaseKind database,
+		AdapterKind adapter
+	)
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var fixture = await CreateFixtureAsync(database, adapter, cancellationToken);
+		var storage = fixture.GraphStorage;
+		var replica = Assert.IsAssignableFrom<IJobStorageReplica>(storage);
+		var now = fixture.TimeProvider.GetUtcNow();
+		var retriedParent = CreateJob("retried-parent", now);
+		var otherParent = CreateJob("other-parent", now.AddTicks(1)) with { DueAt = now };
+		var child = CreateJob("retry-child", now.AddTicks(2)) with { DueAt = now };
+		await storage.EnqueueAsync(retriedParent, cancellationToken);
+		await storage.EnqueueAsync(otherParent, cancellationToken);
+		await storage.EnqueueContinuationAsync(child,
+		[
+			new()
+			{
+				ChildJobId = child.Id,
+				ParentJobId = retriedParent.Id,
+				Trigger = ContinuationTrigger.Complete,
+			},
+			new()
+			{
+				ChildJobId = child.Id,
+				ParentJobId = otherParent.Id,
+				Trigger = ContinuationTrigger.Complete,
+			},
+		], cancellationToken);
+		_ = Assert.Single(await replica.AcquireJobsAsync(
+			[retriedParent.Id],
+			"worker",
+			TimeSpan.FromMinutes(1),
+			cancellationToken
+		));
+		await storage.FailAsync(retriedParent.Id, "worker", "expected", nextRetryAt: null, cancellationToken);
+		await storage.RetryAsync(retriedParent.Id, cancellationToken);
+		_ = Assert.Single(await replica.AcquireJobsAsync(
+			[retriedParent.Id],
+			"worker",
+			TimeSpan.FromMinutes(1),
+			cancellationToken
+		));
+
+		await storage.CompleteAsync(retriedParent.Id, "worker", cancellationToken);
+
+		Assert.Equal(
+			JobState.AwaitingContinuation,
+			(await storage.GetJobStatusAsync(child.Id, cancellationToken))!.State
+		);
+		_ = Assert.Single(await replica.AcquireJobsAsync(
+			[otherParent.Id],
+			"worker",
+			TimeSpan.FromMinutes(1),
+			cancellationToken
+		));
+		await storage.CompleteAsync(otherParent.Id, "worker", cancellationToken);
+		Assert.Equal(JobState.Pending, (await storage.GetJobStatusAsync(child.Id, cancellationToken))!.State);
+	}
+
+	[Theory]
+	[MemberData(nameof(Matrix))]
 	public async Task DynamicAdditionsRejectInvalidBatchIdsBeforeMutation(
 		DatabaseKind database,
 		AdapterKind adapter

--- a/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
+++ b/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
@@ -31,6 +31,13 @@ public sealed class RelationalStorageMatrixTests(StorageContainers containers)
 		AdapterKind.LinqToDB,
 	];
 
+	public static TheoryData<DatabaseKind> LinqToDbDatabases =>
+	[
+		DatabaseKind.Sqlite,
+		DatabaseKind.PostgreSql,
+		DatabaseKind.SqlServer,
+	];
+
 	[Theory]
 	[MemberData(nameof(Matrix))]
 	public async Task AdapterPassesCoreStorageConformance(DatabaseKind database, AdapterKind adapter)
@@ -201,6 +208,56 @@ public sealed class RelationalStorageMatrixTests(StorageContainers containers)
 		Assert.Empty(await first.QueryJobsAsync(new() { Id = "stale-continuation" }, cancellationToken));
 		Assert.Equal("node-b", reclaimed.WorkerId);
 		Assert.Equal(JobState.Active, (await first.GetJobStatusAsync("reclaimed-parent", cancellationToken))!.State);
+	}
+
+	[Theory]
+	[MemberData(nameof(LinqToDbDatabases))]
+	public async Task LinqCompletionSurvivesSustainedBatchHeaderContention(DatabaseKind database)
+	{
+		const int JobCount = 24;
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var fixture = await CreateFixtureAsync(
+			database,
+			AdapterKind.LinqToDB,
+			cancellationToken
+		);
+		var storage = fixture.GraphStorage;
+		var replica = Assert.IsAssignableFrom<IJobStorageReplica>(storage);
+		var now = fixture.TimeProvider.GetUtcNow();
+		var jobs = Enumerable.Range(0, JobCount)
+			.Select(index =>
+			{
+				var id = string.Create(CultureInfo.InvariantCulture, $"contended-completion-{index}");
+				return CreateJob(id, now) with { BatchId = "contended-batch" };
+			})
+			.ToArray();
+		await storage.EnqueueBatchAsync(new()
+		{
+			Id = "contended-batch",
+			CreatedAt = now,
+			TotalJobs = JobCount,
+			PendingCount = JobCount,
+			State = BatchState.Executing,
+		}, jobs, [], cancellationToken);
+		Assert.Equal(JobCount, (await replica.AcquireJobsAsync(
+			[.. jobs.Select(static job => job.Id)],
+			"worker",
+			TimeSpan.FromMinutes(1),
+			cancellationToken
+		)).Count);
+		var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+		var completions = jobs.Select(async job =>
+		{
+			await start.Task;
+			await storage.CompleteAsync(job.Id, "worker", cancellationToken);
+		}).ToArray();
+
+		start.SetResult();
+		await Task.WhenAll(completions);
+
+		var batch = Assert.IsType<BatchStatus>(await storage.GetBatchStatusAsync("contended-batch", cancellationToken));
+		Assert.Equal(BatchState.Succeeded, batch.State);
+		Assert.Equal(JobCount, batch.Succeeded);
 	}
 
 	[Theory]


### PR DESCRIPTION
Summary

- persist continuation parent outcomes and close completion/insertion races
- isolate malformed recurring schedules and align runtime cron parsing with analyzer validation
- harden Redis recurring pause/resume/materialization and bound dedupe state
- implement queued overlap admission
- surface lease loss and make LinqToDB completion/upsert concurrency retry safely

Testing

- `dotnet test Immediate.Jobs.slnx --no-restore -v minimal` (1,173 passed)
- `dotnet build tests/Immediate.Jobs.StorageTests/Immediate.Jobs.StorageTests.csproj -f net10.0 --no-restore -v minimal` (0 warnings, 0 errors)

Fixes #58
Fixes #59
Fixes #60
Fixes #61
Fixes #62
Fixes #63
Fixes #64
Fixes #65
Fixes #66
Fixes #67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cron parsing now normalizes and expands common cron aliases for more compatible recurring schedules.
  * Continuations now record and propagate parent outcomes to improve dependency handling accuracy.

* **Bug Fixes**
  * Improved resilience to concurrency conflicts during graph insertion and recurring upserts via safer retry behavior.
  * Unauthorized job ownership mutations now fail fast instead of silently ignoring.
  * Purging/deleting recurring jobs now consistently removes related recurring dedupe and due-state.

* **Reliability**
  * Failures during individual recurring schedule materialization no longer block other schedules or ordinary job acquisition.
  * Overlap scheduling with queue mode now better enforces serialized acquisition for overlap runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->