### PR TITLE
Fast-forward scheduled jobs from the dashboard

### DIFF
--- a/docs/batches-and-continuations.md
+++ b/docs/batches-and-continuations.md
@@ -570,6 +570,8 @@ edges — a pipeline/graph canvas, not a list.
 
 - **Retry job** — re-runs *only* the selected failed member. Cascade-cancel is terminal, so
   downstream `Cancelled` nodes stay cancelled (see §4.4).
+- **Run now** — fast-forwards any invocation waiting in `Scheduled`, without changing its attempt
+  count or overwriting the latest failure details from an automatic retry.
 - **Retry from here** — re-materializes the failed member **and its cancelled descendants** as a
   fresh sub-DAG (new IDs, new edges) attached to the same batch, rather than resurrecting terminal
   rows. This is the "resume the workflow" action; the viewer shows the re-materialized branch as a

--- a/samples/Aspire/Api/Endpoints/SampleApiEndpoints.cs
+++ b/samples/Aspire/Api/Endpoints/SampleApiEndpoints.cs
@@ -28,6 +28,15 @@ public static class SampleApiEndpoints
 			)
 			.Produces<FairQueueDemoResponse>(StatusCodes.Status202Accepted);
 
+		_ = endpoints.MapPost("/api/retry-demo", EnqueueRetryDemoAsync)
+			.WithName("EnqueueRetryDemo")
+			.WithSummary("Enqueues a job that succeeds on its third attempt")
+			.WithDescription(
+				"The first two attempts fail and schedule a retry five minutes later. Use Run now "
+				+ "in the Immediate.Jobs dashboard to fast-forward each scheduled retry."
+			)
+			.Produces<EnqueueJobResponse>(StatusCodes.Status202Accepted);
+
 		_ = endpoints.MapPost("/api/order-fulfillment-batches", CreateOrderBatchAsync)
 			.WithName("CreateOrderFulfillmentBatch")
 			.WithSummary("Creates a complex order-fulfillment batch")
@@ -103,6 +112,18 @@ public static class SampleApiEndpoints
 				quietJob.Id,
 				new Uri("/jobs", UriKind.Relative)
 			)
+		);
+	}
+
+	private static async ValueTask<IResult> EnqueueRetryDemoAsync(
+		ThirdAttemptSuccessJob.Scheduler scheduler,
+		CancellationToken cancellationToken
+	)
+	{
+		var job = await scheduler.EnqueueAsync(new(Guid.NewGuid()), cancellationToken);
+		return Results.Accepted(
+			"/jobs",
+			new EnqueueJobResponse(job.Id, new Uri("/jobs", UriKind.Relative))
 		);
 	}
 

--- a/samples/Aspire/Api/Jobs/ThirdAttemptSuccessJob.cs
+++ b/samples/Aspire/Api/Jobs/ThirdAttemptSuccessJob.cs
@@ -1,0 +1,41 @@
+using Immediate.Handlers.Shared;
+using Immediate.Jobs.Shared;
+
+namespace Immediate.Jobs.Aspire.Api.Jobs;
+
+[Handler, Job(
+	Name = "third-attempt-success-demo",
+	MaxAttempts = 3,
+	Backoff = BackoffStrategy.Fixed,
+	BackoffBase = "00:05:00"
+)]
+public sealed partial class ThirdAttemptSuccessJob(ILogger<ThirdAttemptSuccessJob> logger)
+{
+	public sealed record Payload(Guid RunId) : IJobRequest
+	{
+		public JobDetails? JobDetails { get; set; }
+	}
+
+	private ValueTask HandleAsync(Payload payload, CancellationToken cancellationToken)
+	{
+		_ = cancellationToken;
+		var details = payload.JobDetails
+			?? throw new InvalidOperationException("Job details were not populated.");
+		if (details.Attempt < 3)
+		{
+			logger.LogWarning(
+				"Retry demo {RunId}: intentionally failing attempt {Attempt}; retry is due in five minutes",
+				payload.RunId,
+				details.Attempt
+			);
+			throw new InvalidOperationException("Expected retry demo failure before the third attempt.");
+		}
+
+		logger.LogInformation(
+			"Retry demo {RunId}: succeeded on attempt {Attempt}",
+			payload.RunId,
+			details.Attempt
+		);
+		return ValueTask.CompletedTask;
+	}
+}

--- a/samples/Aspire/readme.md
+++ b/samples/Aspire/readme.md
@@ -23,6 +23,11 @@ dotnet run --project samples/Aspire/AppHost/Immediate.Jobs.Aspire.AppHost.csproj
 
 Open the Aspire dashboard URL printed in the console, then select the `jobs-api` endpoint. It opens
 Scalar at `/scalar`. `POST /api/greetings/{name}` demonstrates captured request context.
+
+`POST /api/retry-demo` enqueues a job that intentionally fails its first two attempts, waits five
+minutes between retries, and succeeds on attempt three. Once an attempt fails, use **Run now** in
+the Immediate.Jobs dashboard to fast-forward its scheduled retry.
+
 `POST /api/order-fulfillment-batches` creates an atomic ten-job workflow with chains, parallel
 inventory/fraud/payment work, two fan-in joins, and a `Complete` audit continuation. While the
 fraud-check member runs, it uses its `JobDetails` to schedule a retry-safe eleventh member before the
@@ -54,6 +59,7 @@ The raw OpenAPI document is available at `/openapi/v1.json`. You can also enqueu
 
 ```console
 curl -X POST http://localhost:<port>/api/greetings/Ada
+curl -X POST http://localhost:<port>/api/retry-demo
 curl -X POST http://localhost:<port>/api/order-fulfillment-batches
 curl -X POST http://localhost:<port>/api/game-release-batches/Starfall
 ```

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/src/components/JobDetail.vue
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/src/components/JobDetail.vue
@@ -2,7 +2,7 @@
 import { Activity, ExternalLink, RotateCcw, ScrollText, X } from '@lucide/vue';
 
 import StateBadge from '@/components/StateBadge.vue';
-import type { JobRecord, JobTelemetryLink } from '@/contracts';
+import { canRetryJob, type JobRecord, type JobTelemetryLink } from '@/contracts';
 import { formatDate, formatJson } from '@/format';
 
 withDefaults(defineProps<{
@@ -20,6 +20,13 @@ const emit = defineEmits<{
 	close: [];
 	retry: [job: JobRecord];
 }>();
+
+function retryButtonLabel(job: JobRecord, pending: boolean): string {
+	if (pending) {
+		return 'Retrying…';
+	}
+	return job.state === 'Scheduled' ? 'Run now' : 'Retry job';
+}
 </script>
 
 <template>
@@ -38,14 +45,14 @@ const emit = defineEmits<{
 			<div class="flex items-center justify-between gap-3">
 				<StateBadge :state="job.state" />
 				<button
-					v-if="job.state === 'Failed'"
+					v-if="canRetryJob(job)"
 					class="button button-secondary"
 					type="button"
 					:disabled="pending"
 					@click="emit('retry', job)"
 				>
 					<RotateCcw :size="14" aria-hidden="true" />
-					{{ pending ? 'Retrying…' : 'Retry job' }}
+					{{ retryButtonLabel(job, pending) }}
 				</button>
 			</div>
 

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/src/components/JobTable.vue
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/src/components/JobTable.vue
@@ -4,7 +4,7 @@ import { Eye, Layers3, RotateCcw, Trash2 } from '@lucide/vue';
 
 import FeedbackState from '@/components/FeedbackState.vue';
 import StateBadge from '@/components/StateBadge.vue';
-import type { JobRecord } from '@/contracts';
+import { canRetryJob, type JobRecord } from '@/contracts';
 import { formatDate } from '@/format';
 
 const props = withDefaults(defineProps<{
@@ -40,6 +40,10 @@ function selectJob(job: JobRecord): void {
 	if (props.selectedId === job.id) {
 		void scrollJobIntoView(job.id);
 	}
+}
+
+function retryLabel(job: JobRecord): string {
+	return job.state === 'Scheduled' ? `Run ${job.jobName} now` : `Retry ${job.jobName}`;
 }
 
 watch(() => props.selectedId, (jobId) => {
@@ -111,11 +115,11 @@ watch(() => props.selectedId, (jobId) => {
 										<Eye :size="15" aria-hidden="true" />
 									</button>
 									<button
-										v-if="job.state === 'Failed'"
+										v-if="canRetryJob(job)"
 										class="icon-button"
 										type="button"
 										:disabled="busyJobId === job.id"
-										:aria-label="`Retry ${job.jobName}`"
+										:aria-label="retryLabel(job)"
 										@click="emit('retry', job)"
 									>
 										<RotateCcw :size="15" aria-hidden="true" />

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/src/contracts.ts
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/src/contracts.ts
@@ -43,6 +43,10 @@ export interface JobRecord {
 	failedDependencies: number;
 }
 
+export function canRetryJob(job: Pick<JobRecord, 'state'>): boolean {
+	return job.state === 'Failed' || job.state === 'Scheduled';
+}
+
 export interface RecurringJobSchedule {
 	name: string;
 	jobName: string;

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/tests/components.test.ts
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/tests/components.test.ts
@@ -59,6 +59,27 @@ describe('dashboard components', () => {
 		expect(dashboardStyles).toMatch(/\.inline-job-detail \.inspector\s*\{[^}]*overflow:\s*visible/s);
 	});
 
+	it('can fast-forward scheduled jobs', async () => {
+		const scheduled = {
+			...completedJob,
+			id: 'scheduled-retry',
+			jobName: 'retry-test',
+			state: 'Scheduled' as const,
+			attempt: 1,
+			completedAt: null,
+		};
+		const firstRun = { ...scheduled, id: 'scheduled-first-run', jobName: 'first-run', attempt: 0 };
+		const table = mount(JobTable, { props: { rows: [scheduled, firstRun] } });
+
+		expect(table.find('button[aria-label="Run first-run now"]').exists()).toBe(true);
+		const runNow = table.get('button[aria-label="Run retry-test now"]');
+		await runNow.trigger('click');
+		expect(table.emitted('retry')?.[0]).toEqual([scheduled]);
+
+		const detail = mount(JobDetail, { props: { job: scheduled } });
+		expect(detail.get('button.button-secondary').text()).toContain('Run now');
+	});
+
 	it.each([
 		{ groupId: null, rendersGroup: false },
 		{ groupId: '', rendersGroup: true },

--- a/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
+++ b/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
@@ -1271,7 +1271,8 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 		await using var context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 		await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
 		var job = await context.Set<ImmediateJobEntity>()
-			.SingleOrDefaultAsync(item => item.Id == jobId && item.State == JobState.Failed, cancellationToken)
+			.SingleOrDefaultAsync(item => item.Id == jobId &&
+				(item.State == JobState.Failed || item.State == JobState.Scheduled), cancellationToken)
 			.ConfigureAwait(false);
 		if (job is null)
 		{
@@ -1279,13 +1280,14 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 				.AnyAsync(item => item.Id == jobId, cancellationToken)
 				.ConfigureAwait(false))
 			{
-				throw new ImmediateJobException("Only failed jobs can be retried.");
+				throw new ImmediateJobException("Only failed or scheduled jobs can be retried.");
 			}
 
 			throw new KeyNotFoundException($"Job '{jobId}' was not found.");
 		}
 
-		if (job.BatchId is { } batchId)
+		var wasFailed = job.State == JobState.Failed;
+		if (wasFailed && job.BatchId is { } batchId)
 		{
 			var batch = await context.Set<ImmediateJobBatchEntity>()
 				.SingleAsync(item => item.Id == batchId, cancellationToken)
@@ -1301,8 +1303,12 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 		job.DueAt = _timeProvider.GetUtcNow();
 		job.WorkerId = null;
 		job.LeaseExpiresAt = null;
-		job.CompletedAt = null;
-		job.LastError = null;
+		if (wasFailed)
+		{
+			job.CompletedAt = null;
+			job.LastError = null;
+		}
+
 		job.ConcurrencyStamp = Guid.NewGuid();
 		try
 		{
@@ -1318,7 +1324,7 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 				throw new KeyNotFoundException($"Job '{jobId}' was not found.");
 			}
 
-			throw new ImmediateJobException("Only failed jobs can be retried.");
+			throw new ImmediateJobException("Only failed or scheduled jobs can be retried.");
 		}
 
 		await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
+++ b/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
@@ -1321,16 +1321,18 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 	private async Task RetryCoreAsync(DataConnection connection, string jobId, CancellationToken cancellationToken)
 	{
 		var job = await Jobs(connection)
-			.SingleOrDefaultAsync(item => item.Id == jobId && item.State == JobState.Failed, cancellationToken)
+			.SingleOrDefaultAsync(item => item.Id == jobId &&
+				(item.State == JobState.Failed || item.State == JobState.Scheduled), cancellationToken)
 			.ConfigureAwait(false);
 		if (job is null)
 		{
 			if (await Jobs(connection).AnyAsync(item => item.Id == jobId, cancellationToken).ConfigureAwait(false))
-				throw new ImmediateJobException("Only failed jobs can be retried.");
+				throw new ImmediateJobException("Only failed or scheduled jobs can be retried.");
 			throw new KeyNotFoundException($"Job '{jobId}' was not found.");
 		}
 
-		if (job.BatchId is { } batchId)
+		var wasFailed = job.State == JobState.Failed;
+		if (wasFailed && job.BatchId is { } batchId)
 		{
 			var batch = await Batches(connection).SingleAsync(item => item.Id == batchId, cancellationToken).ConfigureAwait(false);
 			var batchStamp = batch.ConcurrencyStamp;
@@ -1348,8 +1350,12 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 		job.DueAt = _timeProvider.GetUtcNow().UtcTicks;
 		job.WorkerId = null;
 		job.LeaseExpiresAt = null;
-		job.CompletedAt = null;
-		job.LastError = null;
+		if (wasFailed)
+		{
+			job.CompletedAt = null;
+			job.LastError = null;
+		}
+
 		job.ConcurrencyStamp = Guid.NewGuid();
 		if (!await UpdateJobAsync(connection, job, oldStamp, cancellationToken).ConfigureAwait(false))
 			throw new LostRaceException();

--- a/src/Immediate.Jobs.Redis/RedisJobStorage.cs
+++ b/src/Immediate.Jobs.Redis/RedisJobStorage.cs
@@ -374,6 +374,7 @@ public sealed class RedisJobStorage : IRecurringJobStorage, IDisposable
 			[
 				JobKey(jobId),
 				StateKey(JobState.Failed),
+				StateKey(JobState.Scheduled),
 				StateKey(JobState.Pending),
 				CompletedKey(JobState.Failed),
 			],
@@ -383,7 +384,7 @@ public sealed class RedisJobStorage : IRecurringJobStorage, IDisposable
 		if (result == 0)
 			throw new KeyNotFoundException($"Job '{jobId}' was not found.");
 		if (result < 0)
-			throw new ImmediateJobException("Only failed jobs can be retried.");
+			throw new ImmediateJobException("Only failed or scheduled jobs can be retried.");
 	}
 
 	/// <inheritdoc />

--- a/src/Immediate.Jobs.Redis/RedisScripts.cs
+++ b/src/Immediate.Jobs.Redis/RedisScripts.cs
@@ -189,15 +189,23 @@ internal static class RedisScripts
 	internal const string Retry =
 		"""
 		if redis.call('EXISTS', KEYS[1]) == 0 then return 0 end
-		local values = redis.call('HMGET', KEYS[1], 'state', 'queue', 'created')
-		if values[1] ~= '6' then return -1 end
+		local values = redis.call('HMGET', KEYS[1], 'state', 'queue', 'created', 'dueMember')
+		local failed = values[1] == '6'
+		local scheduled = values[1] == '2'
+		if not failed and not scheduled then return -1 end
 		redis.call('HSET', KEYS[1],
 			'state', '3', 'due', ARGV[1], 'dueScore', ARGV[2],
 			'dueMember', ARGV[1] .. '|' .. values[3] .. '|' .. ARGV[3],
-			'worker', '', 'lease', '', 'error', '', 'completed', '')
-		redis.call('SREM', KEYS[2], ARGV[3])
-		redis.call('SADD', KEYS[3], ARGV[3])
-		redis.call('ZREM', KEYS[4], ARGV[3])
+			'worker', '', 'lease', '')
+		if failed then
+			redis.call('HSET', KEYS[1], 'error', '', 'completed', '')
+			redis.call('SREM', KEYS[2], ARGV[3])
+			redis.call('ZREM', KEYS[5], ARGV[3])
+		else
+			redis.call('SREM', KEYS[3], ARGV[3])
+			if values[4] then redis.call('ZREM', ARGV[4] .. 'due:' .. values[2], values[4]) end
+		end
+		redis.call('SADD', KEYS[4], ARGV[3])
 		redis.call('ZADD', ARGV[4] .. 'due:' .. values[2], ARGV[2],
 			ARGV[1] .. '|' .. values[3] .. '|' .. ARGV[3])
 		return 1

--- a/src/Immediate.Jobs.Shared/IJobStorage.cs
+++ b/src/Immediate.Jobs.Shared/IJobStorage.cs
@@ -90,8 +90,8 @@ public interface IJobStorage : IAsyncDisposable
 	/// <returns>The job status, or <see langword="null"/> when the invocation does not exist.</returns>
 	ValueTask<JobStatus?> GetJobStatusAsync(string jobId, CancellationToken cancellationToken = default);
 
-	/// <summary>Moves a failed invocation back to pending.</summary>
-	/// <param name="jobId">The failed invocation identifier.</param>
+	/// <summary>Moves a failed invocation back to pending or fast-forwards a scheduled invocation.</summary>
+	/// <param name="jobId">The failed or scheduled invocation identifier.</param>
 	/// <param name="cancellationToken">A token that can cancel the storage operation.</param>
 	/// <returns>A value task that represents the asynchronous retry operation.</returns>
 	ValueTask RetryAsync(string jobId, CancellationToken cancellationToken = default);

--- a/src/Immediate.Jobs.Shared/InMemoryJobStorage.cs
+++ b/src/Immediate.Jobs.Shared/InMemoryJobStorage.cs
@@ -978,17 +978,18 @@ public sealed class InMemoryJobStorage(TimeProvider timeProvider) :
 		{
 			if (!_jobs.TryGetValue(jobId, out var job))
 				throw new KeyNotFoundException($"Job '{jobId}' was not found.");
-			if (job.State != JobState.Failed)
-				throw new ImmediateJobException("Only failed jobs can be retried.");
+			var wasFailed = job.State == JobState.Failed;
+			if (!wasFailed && job.State != JobState.Scheduled)
+				throw new ImmediateJobException("Only failed or scheduled jobs can be retried.");
 
 			_jobs[jobId] = job with
 			{
 				State = JobState.Pending,
 				DueAt = timeProvider.GetUtcNow(),
-				CompletedAt = null,
-				LastError = null,
+				CompletedAt = wasFailed ? null : job.CompletedAt,
+				LastError = wasFailed ? null : job.LastError,
 			};
-			if (job.BatchId is { } batchId && _batches.TryGetValue(batchId, out var batch))
+			if (wasFailed && job.BatchId is { } batchId && _batches.TryGetValue(batchId, out var batch))
 			{
 				_batches[batchId] = batch with
 				{

--- a/tests/Immediate.Jobs.FunctionalTests/Storage/QueueStorageTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/Storage/QueueStorageTests.cs
@@ -47,6 +47,42 @@ public sealed class QueueStorageTests
 	}
 
 	[Fact]
+	public async Task RetryFastForwardsScheduledJobs()
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		var clock = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+		await using var storage = new InMemoryJobStorage(clock);
+		var job = new JobRecord
+		{
+			Id = "scheduled-retry",
+			JobName = "retry-test",
+			Payload = "{}",
+			State = JobState.Scheduled,
+			DueAt = clock.GetUtcNow().AddHours(1),
+			CreatedAt = clock.GetUtcNow(),
+			Attempt = 1,
+			LastError = "expected failure",
+		};
+		await storage.EnqueueAsync(job, cancellationToken);
+
+		await storage.RetryAsync(job.Id, cancellationToken);
+
+		var retried = Assert.Single(await storage.QueryJobsAsync(new() { Id = job.Id }, cancellationToken));
+		Assert.Equal(JobState.Pending, retried.State);
+		Assert.Equal(clock.GetUtcNow(), retried.DueAt);
+		Assert.Equal(1, retried.Attempt);
+		Assert.Equal(job.LastError, retried.LastError);
+
+		var firstRun = job with { Id = "scheduled-first-run", Attempt = 0, LastError = null };
+		await storage.EnqueueAsync(firstRun, cancellationToken);
+		await storage.RetryAsync(firstRun.Id, cancellationToken);
+		var fastForwarded = Assert.Single(await storage.QueryJobsAsync(new() { Id = firstRun.Id }, cancellationToken));
+		Assert.Equal(JobState.Pending, fastForwarded.State);
+		Assert.Equal(clock.GetUtcNow(), fastForwarded.DueAt);
+		Assert.Equal(0, fastForwarded.Attempt);
+	}
+
+	[Fact]
 	public async Task AcquisitionHonorsQueueOrderAndQueueAndJobCapacities()
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;

--- a/tests/Immediate.Jobs.StorageTests/RedisStorageTests.cs
+++ b/tests/Immediate.Jobs.StorageTests/RedisStorageTests.cs
@@ -201,6 +201,39 @@ public sealed class RedisStorageTests(RedisStorageFixture fixture)
 	}
 
 	[Fact]
+	public async Task RetryFastForwardsScheduledJobs()
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var connection = await ConnectionMultiplexer.ConnectAsync(fixture.Container.GetConnectionString());
+		var timeProvider = CreateTimeProvider();
+		await using var storage = new RedisJobStorage(connection, CreateOptions(), timeProvider);
+		var job = CreateJob("scheduled-retry", timeProvider.GetUtcNow()) with
+		{
+			State = JobState.Scheduled,
+			DueAt = timeProvider.GetUtcNow().AddHours(1),
+			Attempt = 1,
+			LastError = "expected failure",
+		};
+		await storage.EnqueueAsync(job, cancellationToken);
+
+		await storage.RetryAsync(job.Id, cancellationToken);
+
+		var retried = Assert.Single(await storage.QueryJobsAsync(new() { Id = job.Id }, cancellationToken));
+		Assert.Equal(JobState.Pending, retried.State);
+		Assert.Equal(timeProvider.GetUtcNow(), retried.DueAt);
+		Assert.Equal(1, retried.Attempt);
+		Assert.Equal(job.LastError, retried.LastError);
+
+		var firstRun = job with { Id = "scheduled-first-run", Attempt = 0, LastError = null };
+		await storage.EnqueueAsync(firstRun, cancellationToken);
+		await storage.RetryAsync(firstRun.Id, cancellationToken);
+		var fastForwarded = Assert.Single(await storage.QueryJobsAsync(new() { Id = firstRun.Id }, cancellationToken));
+		Assert.Equal(JobState.Pending, fastForwarded.State);
+		Assert.Equal(timeProvider.GetUtcNow(), fastForwarded.DueAt);
+		Assert.Equal(0, fastForwarded.Attempt);
+	}
+
+	[Fact]
 	public async Task MissingDashboardActionsThrowKeyNotFoundException()
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;

--- a/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
+++ b/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
@@ -901,6 +901,40 @@ public sealed class RelationalStorageMatrixTests(StorageContainers containers)
 
 	[Theory]
 	[MemberData(nameof(Matrix))]
+	public async Task RetryFastForwardsScheduledJobs(DatabaseKind database, AdapterKind adapter)
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var fixture = await CreateFixtureAsync(database, adapter, cancellationToken);
+		var storage = fixture.Storage;
+		var now = fixture.TimeProvider.GetUtcNow();
+		var job = CreateJob("scheduled-retry", now) with
+		{
+			State = JobState.Scheduled,
+			DueAt = now.AddHours(1),
+			Attempt = 1,
+			LastError = "expected failure",
+		};
+		await storage.EnqueueAsync(job, cancellationToken);
+
+		await storage.RetryAsync(job.Id, cancellationToken);
+
+		var retried = Assert.Single(await storage.QueryJobsAsync(new() { Id = job.Id }, cancellationToken));
+		Assert.Equal(JobState.Pending, retried.State);
+		Assert.Equal(now, retried.DueAt);
+		Assert.Equal(1, retried.Attempt);
+		Assert.Equal(job.LastError, retried.LastError);
+
+		var firstRun = job with { Id = "scheduled-first-run", Attempt = 0, LastError = null };
+		await storage.EnqueueAsync(firstRun, cancellationToken);
+		await storage.RetryAsync(firstRun.Id, cancellationToken);
+		var fastForwarded = Assert.Single(await storage.QueryJobsAsync(new() { Id = firstRun.Id }, cancellationToken));
+		Assert.Equal(JobState.Pending, fastForwarded.State);
+		Assert.Equal(now, fastForwarded.DueAt);
+		Assert.Equal(0, fastForwarded.Attempt);
+	}
+
+	[Theory]
+	[MemberData(nameof(Matrix))]
 	public async Task EmptyBatchProgressIsFullySettled(DatabaseKind database, AdapterKind adapter)
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;


### PR DESCRIPTION
> Stacked on #77. Until #77 merges, GitHub will also show those prerequisite commits; the diff will collapse afterward.

## Summary
- allow RetryAsync to fast-forward any Scheduled invocation, including its first attempt
- preserve attempt and failure metadata while moving the invocation to Pending now
- show Run now in the dashboard for scheduled jobs
- add an Aspire retry demo that fails twice, waits five minutes, and succeeds on attempt three

## Verification
- solution Release build
- dashboard lint, typecheck, and 22 tests
- focused in-memory regression
- 177 Redis and relational storage tests

Part of #79.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added **Run now** support for scheduled jobs, immediately moving them to pending without changing attempt or error details.
  - Dashboard retry actions now show context-aware labels for scheduled and failed jobs.
  - Added a retry demonstration endpoint and sample job that succeeds on its third attempt.

- **Bug Fixes**
  - Missing recurring schedules now return a clear not-found error instead of silently failing.

- **Documentation**
  - Documented scheduled-job fast-forwarding and the new retry demonstration endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->