### PR TITLE
Add a durable skipped job state

### DIFF
--- a/docs/batches-and-continuations.md
+++ b/docs/batches-and-continuations.md
@@ -51,7 +51,7 @@ dispatch resolves the job through the same generated `IJobInvoker`. No reflectio
 Continuations preserve this property. `child.ScheduleAfterAsync(parent, payload)` does **not** defer code.
 It writes a real, fully-serialized `JobRecord` for the child *now*, parked in a new
 `AwaitingContinuation` state, plus one or more **edges** describing what it waits for. When a parent
-reaches a terminal state, storage flips the child to `Pending` (or `Cancelled`). The only new
+reaches a terminal state, storage flips the child to `Pending` (or `Skipped`). The only new
 durable data is **edges and counters** — never behavior.
 
 ---
@@ -167,7 +167,7 @@ await two.ScheduleAfterAsync(oneBJob, new());           // `two` runs after `one
 
 > A standalone `ScheduleAfterAsync` and its parent are two separate writes, so the parent may already be
 > terminal by the time the child is created. In that case the continuation is **evaluated
-> immediately** (released or cancelled per its trigger) rather than waiting forever. Inside a batch
+> immediately** (released or skipped per its trigger) rather than waiting forever. Inside a batch
 > the two are written atomically, so this race cannot occur.
 
 ### 3.4 Fan-in / join
@@ -297,11 +297,11 @@ dashboard (§7).
 
 ### 3.8 Continuation triggers
 
-| Trigger                 | Fires when …                                               | When the condition is not met                    |
-| ----------------------- | ---------------------------------------------------------- | ------------------------------------------------ |
-| `Success` **(default)** | every parent reached `Succeeded`                           | child is **cancelled**, cascading to its subtree |
-| `Failure`               | every parent is terminal and at least one reached `Failed` | child is **cancelled**, cascading to its subtree |
-| `Complete`              | every parent reached any terminal state                    | always runs                                      |
+| Trigger                 | Fires when …                                               | When the condition is not met                  |
+| ----------------------- | ---------------------------------------------------------- | ---------------------------------------------- |
+| `Success` **(default)** | every parent reached `Succeeded`                           | child is **skipped**, cascading to its subtree |
+| `Failure`               | every parent is terminal and at least one reached `Failed` | child is **skipped**, cascading to its subtree |
+| `Complete`              | every parent reached any terminal state                    | always runs                                    |
 
 `Success` is the safe default: a broken upstream step never silently runs downstream work.
 `Failure` is the failure-handler trigger. For a `BatchHandle`, it fires only when the aggregate
@@ -333,7 +333,7 @@ await handleImportFailure.ScheduleAfterAsync(
 A new lifecycle state parks pre-created continuation rows, plus one reserved state:
 
 ```
-Scheduled → Pending → Active → Succeeded | Failed | Cancelled
+Scheduled → Pending → Active → Succeeded | Failed | Cancelled | Skipped
                  ↑
    AwaitingContinuation   (created, ineligible until every incoming edge is satisfied)
    AwaitingParameters     (reserved; ineligible until required inputs are supplied → Pending)
@@ -358,13 +358,16 @@ like `AwaitingContinuation`.
 | `PendingCount`   | int             | Non-terminal members; decremented as members reach terminal state |
 | `SucceededCount` | int             | Members that succeeded (maintained in §4.4)       |
 | `FailedCount`    | int             | Members that failed                               |
-| `CancelledCount` | int             | Members cancelled (incl. cascade)                 |
+| `CancelledCount` | int             | Members cancelled by an explicit action           |
+| `SkippedCount`   | int             | Conditional branches whose trigger was not selected |
 | `StartedAt`      | timestamptz?    | Set when the first member goes `Active`           |
 | `CompletedAt`    | timestamptz?    | Set when `State` becomes terminal                 |
 | `State`          | enum            | `Executing | Succeeded | Failed | Cancelled`      |
 
-The three per-state counters (plus `PendingCount`) make `GetStatusAsync` (§8) a single-row read; they
+The four per-state counters (plus `PendingCount`) make `GetStatusAsync` (§8) a single-row read; they
 are incremented in the same completion transaction that already decrements `PendingCount`.
+Existing EF Core databases need an application migration that adds non-null `SkippedCount` with a
+default of `0`; the LinqToDB bootstrap helper remains fresh-schema-only.
 
 **`immediate_job_continuations`** (edge table — expresses arbitrary DAGs)
 
@@ -412,21 +415,22 @@ unit commits, so a worker cannot observe a partial batch.
 transaction** as the state change:
 
 1. If the job belongs to a batch, decrement `PendingCount` and increment the matching
-   `Succeeded`/`Failed`/`CancelledCount` (and set `StartedAt` on the first `Active` transition); if
+   `SucceededCount`/`FailedCount`/`CancelledCount`/`SkippedCount` (and set `StartedAt` on the first `Active` transition); if
    `PendingCount` reaches `0`, finalize the batch's `State`, stamp `CompletedAt`, and treat the batch
    as a terminal parent for batch→job edges.
 2. For each outgoing edge from this job (or batch), decrement the child's `RemainingDependencies`
    and increment `FailedDependencies` when the parent failed.
-   - **`Success`:** a non-successful parent immediately moves the child to `Cancelled`; otherwise,
+   - **`Success`:** a non-successful parent immediately moves the child to `Skipped`; otherwise,
      release it when `RemainingDependencies` reaches `0`.
    - **`Failure`:** wait until `RemainingDependencies` reaches `0`, then release if
-     `FailedDependencies > 0`; otherwise move the child to `Cancelled`.
+     `FailedDependencies > 0`; otherwise move the child to `Skipped`.
    - **`Complete`:** release when `RemainingDependencies` reaches `0`, regardless of outcomes.
-   Cancellation **recurses** through outgoing edges, cascading the resulting outcome through the
+   Skipping **recurses** through outgoing edges, cascading the resulting outcome through the
    subtree.
 
-Release and cancellation are set-based within the provider (EF Core: `ExecuteUpdate` over the
-affected edge/child set) so a wide fan-out doesn't degrade to N round-trips.
+Release and skipping are committed atomically with the parent terminal transition. Relational
+providers evaluate and update the affected edges and children within the same transaction, so a
+worker cannot observe a terminal parent before its continuations have been evaluated.
 
 ### 4.5 Mid-job scheduling mechanics
 
@@ -500,7 +504,7 @@ still within its window.
 - **Distributed safety.** Counter decrements and edge evaluation run inside the same optimistic-
   concurrency transaction as the terminal state change, so concurrent completions on different nodes
   can't double-release or lose a decrement. A released child is claimable by any node.
-- **Crash mid-cascade.** Because release/cancel is transactional with completion, a node dying
+- **Crash mid-cascade.** Because release/skipping is transactional with completion, a node dying
   leaves either the pre- or post-completion state — never a half-released fan-out. Orphan sweeps
   (already used for expired leases) also reconcile any `AwaitingContinuation` row whose every parent
   is terminal but whose release was interrupted.
@@ -539,7 +543,7 @@ dashboard renders it as a graph rather than a flat job list.
 
 A table of batches with live progress, one row each:
 
-- A compact **progress bar** segmented by state — succeeded / failed / cancelled / running / waiting
+- A compact **progress bar** segmented by state — succeeded / failed / cancelled / skipped / running / waiting
   of `TotalJobs` — updated over SSE.
 - Batch `State` badge (`Executing`, `Succeeded`, `Failed`, `Cancelled`), member count, age, and the
   originating job/queue.
@@ -551,12 +555,12 @@ The centrepiece: an auto-laid-out **left-to-right DAG** of the batch's members a
 edges — a pipeline/graph canvas, not a list.
 
 - **Nodes** are jobs, colour-coded by state (waiting · scheduled · running · succeeded · failed ·
-  cancelled), labelled with the job name; a running node shows a subtle pulse, a failed node a
+  cancelled · skipped), labelled with the job name; a running node shows a subtle pulse, a failed node a
   badge. Selecting a node opens the existing job-detail panel (payload, attempts, errors, timings)
   in a side drawer without leaving the graph.
 - **Edges** are continuation dependencies, drawn `parent → child` and styled by trigger
   (`Success` solid, `Failure` red/dotted, `Complete` dashed). Fan-out, fan-in (join), and diamonds render as their
-  true shape; a **violated `Success` edge and the subtree it cancelled are dimmed/struck** so a
+  true shape; a **violated `Success` edge and the subtree it skipped are dimmed/struck** so a
   cascade is visible at a glance.
 - **Layered layout** (topological rank) with pan/zoom and a mini-map for large fan-outs; nodes with
   hundreds of siblings collapse into a **"×N same job"** group that expands on demand, so a
@@ -568,14 +572,14 @@ edges — a pipeline/graph canvas, not a list.
 
 ### 7.3 Actions
 
-- **Retry job** — re-runs *only* the selected failed member. Cascade-cancel is terminal, so
-  downstream `Cancelled` nodes stay cancelled (see §4.4).
+- **Retry job** — re-runs *only* the selected failed member. Skipped branches are terminal, so
+  downstream `Skipped` nodes stay skipped (see §4.4).
 - **Run now** — fast-forwards any invocation waiting in `Scheduled`, without changing its attempt
   count or overwriting the latest failure details from an automatic retry.
-- **Retry from here** — re-materializes the failed member **and its cancelled descendants** as a
+- **Retry from here** — re-materializes the failed member **and its skipped descendants** as a
   fresh sub-DAG (new IDs, new edges) attached to the same batch, rather than resurrecting terminal
   rows. This is the "resume the workflow" action; the viewer shows the re-materialized branch as a
-  new generation grafted onto the graph, with the original cancelled subtree preserved for history.
+  new generation grafted onto the graph, with the original skipped subtree preserved for history.
 - **Cancel batch** — cascades to all non-terminal members.
 - **Delete batch** — removes a terminal batch as a unit (members + edges), consistent with §4.7.
 
@@ -621,7 +625,7 @@ Result records:
 ```csharp
 public sealed record BatchStatus(
     string Id, BatchState State,
-    int Total, int Succeeded, int Failed, int Cancelled,
+    int Total, int Succeeded, int Failed, int Cancelled, int Skipped,
     int Remaining,                          // non-terminal (running + waiting); == PendingCount
     DateTimeOffset CreatedAt, DateTimeOffset? StartedAt, DateTimeOffset? CompletedAt,
     double FractionSettled);                // empty = 1; otherwise (Total - Remaining) / Total
@@ -669,7 +673,7 @@ Each maps to a storage call over the batch/member/edge tables already defined �
 - `JobTestHarness.Batches` — build and commit batches against the in-memory provider under
   `FakeTimeProvider`.
 - Assertions: `AssertBatchCommittedAtomicallyAsync`, `AssertContinuationReleasedAfterAsync(parent)`,
-  `AssertCascadeCancelledAsync(subtree)`.
+  and `AssertCascadeSkippedAsync(subtree)` (`AssertCascadeCancelledAsync` remains a compatibility alias).
 - Advance-and-drain helpers already resolve delayed members; continuation release is deterministic
   because it is driven by completion, not wall-clock.
 
@@ -762,7 +766,7 @@ public enum ContinuationOptions
 | **B0**      | v1 scheduler change: `EnqueueAsync`/`ScheduleAsync`/`ScheduleAtAsync` return `JobHandle` instead of `string`     |
 | **B1**      | `IJobBatchScheduler` + `Begin`/`AddToBatch`/`CommitAsync`, atomic `EnqueueBatchAsync`, in-memory + EF Core |
 | **B2**      | `ScheduleAfterAsync` continuations (chains + fan-out), `AwaitingContinuation`, transactional release   |
-| **B3**      | Fan-in joins (`ScheduleAfterAsync([...])`), cascade-cancel, cycle detection, batch continuations (`Begin(after:)`) |
+| **B3**      | Fan-in joins (`ScheduleAfterAsync([...])`), cascade-skipping, cycle detection, batch continuations (`Begin(after:)`) |
 | **B4**      | Mid-job scheduling (§3.6) — `ScheduleAfter`/`AddToBatchAsync(JobDetails, …)`, `ContinuationOptions`, execution buffer + flush, `IJOB0015` |
 | **B5**      | Read API (§8) — `IJobBatchMonitor` + `IJobMonitor`, batch-row counters, backing storage reads    |
 | **B6**      | Batch-atom retention (§4.7), dashboard batches list + workflow viewer + retry/cancel/delete, testing helpers, docs |
@@ -776,9 +780,9 @@ public enum ContinuationOptions
   state (`BatchSucceededRetention` 24h / `BatchFailedRetention` 7d), not member-by-member — so a
   failed DAG can be inspected whole. *(Rejected: inheriting per-member job retention, which leaves
   half-purged batches and wrong aggregate counts.)*
-- **Partial retry (§7.3):** cascade-cancel stays terminal. "Retry job" re-runs only the failed
+- **Partial retry (§7.3):** cascade-skipped work stays terminal. "Retry job" re-runs only the failed
   member; a separate **"Retry from here"** action (B7) re-materializes the failed member and its
-  cancelled descendants as a fresh sub-DAG rather than resurrecting terminal rows. *(Rejected:
+  skipped descendants as a fresh sub-DAG rather than resurrecting terminal rows. *(Rejected:
   un-cancelling terminal rows, which would poison every "terminal is final" assumption in purge,
   cascade, and metrics.)*
 

--- a/samples/Aspire/Api/Contracts/SampleApiResponses.cs
+++ b/samples/Aspire/Api/Contracts/SampleApiResponses.cs
@@ -11,6 +11,17 @@ public sealed record FairQueueDemoResponse(
 	Uri DashboardUrl
 );
 
+public sealed record CreateContinuationBranchDemoResponse(
+	Guid RunId,
+	bool RootWillFail,
+	string BatchId,
+	string RootJobId,
+	string SuccessJobId,
+	string FailureJobId,
+	Uri DashboardUrl,
+	Uri StatusUrl
+);
+
 public sealed record CreateOrderBatchResponse(
 	Guid OrderId,
 	string BatchId,

--- a/samples/Aspire/Api/Endpoints/SampleApiEndpoints.cs
+++ b/samples/Aspire/Api/Endpoints/SampleApiEndpoints.cs
@@ -37,6 +37,18 @@ public static class SampleApiEndpoints
 			)
 			.Produces<EnqueueJobResponse>(StatusCodes.Status202Accepted);
 
+		_ = endpoints.MapPost(
+				"/api/continuation-branch-demo/{failRoot:bool}",
+				CreateContinuationBranchDemoAsync
+			)
+			.WithName("CreateContinuationBranchDemo")
+			.WithSummary("Creates success and failure continuations for one root job")
+			.WithDescription(
+				"Creates an atomic three-job workflow. Set failRoot to choose whether the success "
+				+ "or failure continuation runs; the unselected branch becomes Skipped."
+			)
+			.Produces<CreateContinuationBranchDemoResponse>(StatusCodes.Status202Accepted);
+
 		_ = endpoints.MapPost("/api/order-fulfillment-batches", CreateOrderBatchAsync)
 			.WithName("CreateOrderFulfillmentBatch")
 			.WithSummary("Creates a complex order-fulfillment batch")
@@ -124,6 +136,47 @@ public static class SampleApiEndpoints
 		return Results.Accepted(
 			"/jobs",
 			new EnqueueJobResponse(job.Id, new Uri("/jobs", UriKind.Relative))
+		);
+	}
+
+	private static async ValueTask<IResult> CreateContinuationBranchDemoAsync(
+		bool failRoot,
+		IJobBatchScheduler batches,
+		ContinuationBranchRootJob.Scheduler rootScheduler,
+		ContinuationBranchSuccessJob.Scheduler successScheduler,
+		ContinuationBranchFailureJob.Scheduler failureScheduler,
+		CancellationToken cancellationToken
+	)
+	{
+		var runId = Guid.NewGuid();
+		await using var batch = batches.Begin();
+		var root = rootScheduler.AddToBatch(batch, new(runId, failRoot));
+		var success = await successScheduler.ScheduleAfterAsync(
+			root,
+			new(runId),
+			ContinuationTrigger.Success,
+			cancellationToken: cancellationToken
+		);
+		var failure = await failureScheduler.ScheduleAfterAsync(
+			root,
+			new(runId),
+			ContinuationTrigger.Failure,
+			cancellationToken: cancellationToken
+		);
+		var batchHandle = await batch.CommitAsync(cancellationToken);
+
+		return Results.Accepted(
+			$"/jobs/api/batches/{batchHandle.Id}",
+			new CreateContinuationBranchDemoResponse(
+				runId,
+				failRoot,
+				batchHandle.Id,
+				root.Id,
+				success.Id,
+				failure.Id,
+				new Uri("/jobs", UriKind.Relative),
+				new Uri($"/jobs/api/batches/{batchHandle.Id}", UriKind.Relative)
+			)
 		);
 	}
 

--- a/samples/Aspire/Api/Jobs/ContinuationBranchDemoJobs.cs
+++ b/samples/Aspire/Api/Jobs/ContinuationBranchDemoJobs.cs
@@ -1,0 +1,54 @@
+using Immediate.Handlers.Shared;
+using Immediate.Jobs.Shared;
+
+namespace Immediate.Jobs.Aspire.Api.Jobs;
+
+[Handler, Job(Name = "continuation-branch-root", MaxAttempts = 1)]
+public sealed partial class ContinuationBranchRootJob(ILogger<ContinuationBranchRootJob> logger)
+{
+	public sealed record Payload(Guid RunId, bool Fail);
+
+	private async ValueTask HandleAsync(Payload payload, CancellationToken cancellationToken)
+	{
+		logger.LogInformation(
+			"Continuation branch demo {RunId}: running root job; intentional failure is {Fail}",
+			payload.RunId,
+			payload.Fail
+		);
+		await Task.Delay(TimeSpan.FromMilliseconds(750), cancellationToken);
+		if (payload.Fail)
+			throw new InvalidOperationException("Expected continuation branch demo failure.");
+	}
+}
+
+[Handler, Job(Name = "continuation-branch-success")]
+public sealed partial class ContinuationBranchSuccessJob(ILogger<ContinuationBranchSuccessJob> logger)
+{
+	public sealed record Payload(Guid RunId);
+
+	private ValueTask HandleAsync(Payload payload, CancellationToken cancellationToken)
+	{
+		_ = cancellationToken;
+		logger.LogInformation(
+			"Continuation branch demo {RunId}: the success branch ran",
+			payload.RunId
+		);
+		return ValueTask.CompletedTask;
+	}
+}
+
+[Handler, Job(Name = "continuation-branch-failure")]
+public sealed partial class ContinuationBranchFailureJob(ILogger<ContinuationBranchFailureJob> logger)
+{
+	public sealed record Payload(Guid RunId);
+
+	private ValueTask HandleAsync(Payload payload, CancellationToken cancellationToken)
+	{
+		_ = cancellationToken;
+		logger.LogInformation(
+			"Continuation branch demo {RunId}: the failure branch ran",
+			payload.RunId
+		);
+		return ValueTask.CompletedTask;
+	}
+}

--- a/samples/Aspire/readme.md
+++ b/samples/Aspire/readme.md
@@ -28,6 +28,11 @@ Scalar at `/scalar`. `POST /api/greetings/{name}` demonstrates captured request 
 minutes between retries, and succeeds on attempt three. Once an attempt fails, use **Run now** in
 the Immediate.Jobs dashboard to fast-forward its scheduled retry.
 
+`POST /api/continuation-branch-demo/{failRoot}` creates one root job with success and failure
+continuations. Pass `false` to run the success branch or `true` to run the failure branch; the
+unselected branch is recorded as `Skipped` in the Immediate.Jobs dashboard. The jobs use positional
+record payloads.
+
 `POST /api/order-fulfillment-batches` creates an atomic ten-job workflow with chains, parallel
 inventory/fraud/payment work, two fan-in joins, and a `Complete` audit continuation. While the
 fraud-check member runs, it uses its `JobDetails` to schedule a retry-safe eleventh member before the
@@ -60,6 +65,8 @@ The raw OpenAPI document is available at `/openapi/v1.json`. You can also enqueu
 ```console
 curl -X POST http://localhost:<port>/api/greetings/Ada
 curl -X POST http://localhost:<port>/api/retry-demo
+curl -X POST http://localhost:<port>/api/continuation-branch-demo/false
+curl -X POST http://localhost:<port>/api/continuation-branch-demo/true
 curl -X POST http://localhost:<port>/api/order-fulfillment-batches
 curl -X POST http://localhost:<port>/api/game-release-batches/Starfall
 ```

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/src/components/BatchTable.vue
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/src/components/BatchTable.vue
@@ -54,6 +54,7 @@ function width(value: number, total: number): string {
 								<span data-state="succeeded" :style="{ width: width(batch.succeeded, batch.total) }" />
 								<span data-state="failed" :style="{ width: width(batch.failed, batch.total) }" />
 								<span data-state="cancelled" :style="{ width: width(batch.cancelled, batch.total) }" />
+								<span data-state="skipped" :style="{ width: width(batch.skipped, batch.total) }" />
 								<span data-state="remaining" :style="{ width: width(batch.remaining, batch.total) }" />
 							</div>
 						</td>

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/src/contracts.ts
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/src/contracts.ts
@@ -7,6 +7,7 @@ export const jobStates = [
 	'Succeeded',
 	'Failed',
 	'Cancelled',
+	'Skipped',
 ] as const;
 
 export type JobState = (typeof jobStates)[number];
@@ -87,6 +88,7 @@ export interface BatchStatus {
 	succeeded: number;
 	failed: number;
 	cancelled: number;
+	skipped: number;
 	remaining: number;
 	createdAt: IsoDateTime;
 	startedAt: IsoDateTime | null;

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/src/styles.css
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/src/styles.css
@@ -988,6 +988,11 @@ tbody tr[data-selected="true"] td:first-child {
 	background: var(--text-subtle);
 }
 
+.batch-progress span[data-state="skipped"] {
+	background: var(--info);
+	opacity: 0.55;
+}
+
 .batch-progress span[data-state="remaining"] {
 	background: var(--warning);
 	opacity: 0.55;
@@ -1116,7 +1121,8 @@ tbody tr[data-selected="true"] td:first-child {
 	animation: workflow-pulse 1.6s infinite;
 }
 
-.workflow-node.cancelled {
+.workflow-node.cancelled,
+.workflow-node.skipped {
 	opacity: 0.5;
 }
 

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/src/views/OverviewView.vue
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/src/views/OverviewView.vue
@@ -30,6 +30,7 @@ const summaryStates: JobState[] = [
 	'Succeeded',
 	'Failed',
 	'Cancelled',
+	'Skipped',
 ];
 
 const snapshot = computed(() => overviewQuery.data.value);
@@ -37,7 +38,8 @@ const error = computed(() => overviewQuery.error.value ?? recentJobsQuery.error.
 
 watch(snapshot, (value) => {
 	if (value && dashboardHistory.value.length === 0) {
-		const complete = (value.counts.Succeeded ?? 0) + (value.counts.Failed ?? 0);
+		const complete = (value.counts.Succeeded ?? 0) + (value.counts.Failed ?? 0)
+			+ (value.counts.Cancelled ?? 0) + (value.counts.Skipped ?? 0);
 		dashboardHistory.value = [{
 			capturedAt: value.capturedAt,
 			complete,

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/tests/components.test.ts
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/tests/components.test.ts
@@ -80,6 +80,13 @@ describe('dashboard components', () => {
 		expect(detail.get('button.button-secondary').text()).toContain('Run now');
 	});
 
+	it('shows skipped branches', () => {
+		const skipped = { ...completedJob, id: 'skipped', state: 'Skipped' as const };
+		const table = mount(JobTable, { props: { rows: [skipped] } });
+
+		expect(table.text()).toContain('Skipped');
+	});
+
 	it.each([
 		{ groupId: null, rendersGroup: false },
 		{ groupId: '', rendersGroup: true },

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/tests/fixtures.ts
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/tests/fixtures.ts
@@ -33,6 +33,7 @@ export const executingBatch: BatchStatus = {
 	succeeded: 6,
 	failed: 1,
 	cancelled: 1,
+	skipped: 0,
 	remaining: 2,
 	createdAt: '2026-07-21T12:00:00Z',
 	startedAt: '2026-07-21T12:00:01Z',

--- a/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
+++ b/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
@@ -143,6 +143,7 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 			var succeeded = terminal.Count(static job => job.State == JobState.Succeeded);
 			var failed = terminal.Count(static job => job.State == JobState.Failed);
 			var cancelled = terminal.Count(static job => job.State == JobState.Cancelled);
+			var skipped = terminal.Count(static job => job.State == JobState.Skipped);
 			_ = context.Add(new ImmediateJobBatchEntity
 			{
 				Id = batch.Id,
@@ -152,6 +153,7 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 				SucceededCount = succeeded,
 				FailedCount = failed,
 				CancelledCount = cancelled,
+				SkippedCount = skipped,
 				StartedAt = batch.StartedAt,
 				CompletedAt = pending == 0 ? batch.CompletedAt ?? _timeProvider.GetUtcNow() : null,
 				State = pending == 0 ? GetTerminalBatchState(failed, cancelled) : BatchState.Executing,
@@ -1195,17 +1197,18 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 			.Where(job => job.BatchId == batchId)
 			.ToListAsync(cancellationToken)
 			.ConfigureAwait(false);
-		foreach (var job in jobs)
+		var jobsToCancel = jobs.Where(job => !IsTerminal(job.State)).ToArray();
+		foreach (var job in jobsToCancel)
 		{
-			if (IsTerminal(job.State))
-				continue;
 			job.State = JobState.Cancelled;
 			job.CompletedAt = now;
 			job.WorkerId = null;
 			job.LeaseExpiresAt = null;
 			job.ConcurrencyStamp = Guid.NewGuid();
-			await PropagateTerminalAsync(context, job, now, cancellationToken).ConfigureAwait(false);
 		}
+
+		foreach (var job in jobsToCancel)
+			await PropagateTerminalAsync(context, job, now, cancellationToken).ConfigureAwait(false);
 
 		var terminalGroups = GetTerminalFairQueueGroups(context);
 		_ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
@@ -1347,7 +1350,7 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 		var job = await context.Set<ImmediateJobEntity>()
 			.AsNoTracking()
 			.SingleOrDefaultAsync(item => item.Id == jobId
-				&& (item.State == JobState.Succeeded || item.State == JobState.Failed || item.State == JobState.Cancelled), cancellationToken)
+				&& (item.State == JobState.Succeeded || item.State == JobState.Failed || item.State == JobState.Cancelled || item.State == JobState.Skipped), cancellationToken)
 			.ConfigureAwait(false);
 		if (job is null)
 		{
@@ -1370,7 +1373,7 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 			.ConfigureAwait(false);
 		var removed = await context.Set<ImmediateJobEntity>()
 			.Where(item => item.Id == jobId &&
-				(item.State == JobState.Succeeded || item.State == JobState.Failed || item.State == JobState.Cancelled))
+				(item.State == JobState.Succeeded || item.State == JobState.Failed || item.State == JobState.Cancelled || item.State == JobState.Skipped))
 			.ExecuteDeleteAsync(cancellationToken)
 			.ConfigureAwait(false);
 		if (removed == 0)
@@ -1435,7 +1438,7 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 		var jobs = await context.Set<ImmediateJobEntity>()
 			.Where(job => job.BatchId == null
 				&& ((job.State == JobState.Succeeded && job.CompletedAt < succeededBefore)
-				|| ((job.State == JobState.Failed || job.State == JobState.Cancelled) && job.CompletedAt < failedBefore))
+				|| ((job.State == JobState.Failed || job.State == JobState.Cancelled || job.State == JobState.Skipped) && job.CompletedAt < failedBefore))
 			)
 			.ToListAsync(cancellationToken)
 			.ConfigureAwait(false);
@@ -1923,14 +1926,14 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 					child.FailedDependencies++;
 				if (child.RemainingDependencies == 0)
 				{
-					var cancel = await ShouldCancelSettledContinuationAsync(
+					var skip = await ShouldSkipSettledContinuationAsync(
 						context,
 						child.Id,
 						cancellationToken
 					).ConfigureAwait(false);
-					if (cancel)
+					if (skip)
 					{
-						child.State = JobState.Cancelled;
+						child.State = JobState.Skipped;
 						child.CompletedAt = now;
 						parents.Enqueue((ContinuationParentKind.Job, child.Id, ContinuationParentOutcome.Other));
 						await UpdateBatchForTerminalJobAsync(context, child, now, parents, cancellationToken).ConfigureAwait(false);
@@ -1946,7 +1949,7 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 		}
 	}
 
-	private static async Task<bool> ShouldCancelSettledContinuationAsync(
+	private static async Task<bool> ShouldSkipSettledContinuationAsync(
 		TContext context,
 		string childJobId,
 		CancellationToken cancellationToken
@@ -1994,6 +1997,9 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 				break;
 			case JobState.Cancelled:
 				batch.CancelledCount++;
+				break;
+			case JobState.Skipped:
+				batch.SkippedCount++;
 				break;
 			case JobState.AwaitingContinuation:
 			case JobState.AwaitingParameters:
@@ -2100,7 +2106,7 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 				job.FailedDependencies = failedDependencies;
 				if (violated || (remaining == 0 && requiresFailure && failedDependencies == 0))
 				{
-					job.State = JobState.Cancelled;
+					job.State = JobState.Skipped;
 					job.RemainingDependencies = 0;
 					job.CompletedAt = now;
 					changed = true;
@@ -2171,7 +2177,7 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 	}
 
 	private static bool IsTerminal(JobState state) =>
-		state is JobState.Succeeded or JobState.Failed or JobState.Cancelled;
+		state is JobState.Succeeded or JobState.Failed or JobState.Cancelled or JobState.Skipped;
 
 	private static ContinuationParentOutcome GetParentOutcome(JobState state) => state switch
 	{
@@ -2182,7 +2188,8 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 		JobState.Scheduled or
 		JobState.Pending or
 		JobState.Active or
-		JobState.Cancelled => ContinuationParentOutcome.Other,
+		JobState.Cancelled or
+		JobState.Skipped => ContinuationParentOutcome.Other,
 		_ => throw new ArgumentOutOfRangeException(nameof(state), state, "Unknown job state."),
 	};
 
@@ -2355,6 +2362,7 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 		batch.SucceededCount,
 		batch.FailedCount,
 		batch.CancelledCount,
+		batch.SkippedCount,
 		batch.PendingCount,
 		batch.CreatedAt,
 		batch.StartedAt,

--- a/src/Immediate.Jobs.EntityFrameworkCore/ImmediateJobsModelBuilderExtensions.cs
+++ b/src/Immediate.Jobs.EntityFrameworkCore/ImmediateJobsModelBuilderExtensions.cs
@@ -181,6 +181,7 @@ internal sealed class ImmediateJobBatchEntity
 	public int SucceededCount { get; set; }
 	public int FailedCount { get; set; }
 	public int CancelledCount { get; set; }
+	public int SkippedCount { get; set; }
 	public DateTimeOffset? StartedAt { get; set; }
 	public DateTimeOffset? CompletedAt { get; set; }
 	public BatchState State { get; set; }

--- a/src/Immediate.Jobs.LinqToDB/LinqToDBEntities.cs
+++ b/src/Immediate.Jobs.LinqToDB/LinqToDBEntities.cs
@@ -34,6 +34,8 @@ internal sealed class ImmediateJobBatchEntity
 	public int FailedCount { get; set; }
 	[Column]
 	public int CancelledCount { get; set; }
+	[Column]
+	public int SkippedCount { get; set; }
 	[Column(DataType = DataType.Int64, CanBeNull = true)]
 	public long? StartedAt { get; set; }
 	[Column(DataType = DataType.Int64, CanBeNull = true)]

--- a/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
+++ b/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
@@ -155,6 +155,7 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 			var pending = jobEntities.Count - terminal.Length;
 			var failed = terminal.Count(static job => job.State == JobState.Failed);
 			var cancelled = terminal.Count(static job => job.State == JobState.Cancelled);
+			var skipped = terminal.Count(static job => job.State == JobState.Skipped);
 			_ = await InsertAsync(connection, new ImmediateJobBatchEntity
 			{
 				Id = batch.Id,
@@ -164,6 +165,7 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 				SucceededCount = terminal.Count(static job => job.State == JobState.Succeeded),
 				FailedCount = failed,
 				CancelledCount = cancelled,
+				SkippedCount = skipped,
 				StartedAt = Ticks(batch.StartedAt),
 				CompletedAt = pending == 0 ? Ticks(batch.CompletedAt ?? _timeProvider.GetUtcNow()) : null,
 				State = pending == 0 ? GetTerminalBatchState(failed, cancelled) : BatchState.Executing,
@@ -1250,6 +1252,7 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 			throw new ImmediateJobException("Only an executing batch can be cancelled.");
 		var jobIds = await Jobs(connection).Where(job => job.BatchId == batchId).Select(job => job.Id)
 			.ToArrayAsync(cancellationToken).ConfigureAwait(false);
+		var jobsToCancel = new List<ImmediateJobEntity>(jobIds.Length);
 		foreach (var jobId in jobIds)
 		{
 			var job = await Jobs(connection).SingleOrDefaultAsync(item => item.Id == jobId, cancellationToken)
@@ -1264,6 +1267,11 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 			job.ConcurrencyStamp = Guid.NewGuid();
 			if (!await UpdateJobAsync(connection, job, oldStamp, cancellationToken).ConfigureAwait(false))
 				throw new LostRaceException();
+			jobsToCancel.Add(job);
+		}
+
+		foreach (var job in jobsToCancel)
+		{
 			await PropagateTerminalAsync(
 				connection,
 				job,
@@ -1370,7 +1378,7 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 		try
 		{
 			var job = await Jobs(connection).SingleOrDefaultAsync(item => item.Id == jobId &&
-				(item.State == JobState.Succeeded || item.State == JobState.Failed || item.State == JobState.Cancelled), cancellationToken)
+				(item.State == JobState.Succeeded || item.State == JobState.Failed || item.State == JobState.Cancelled || item.State == JobState.Skipped), cancellationToken)
 				.ConfigureAwait(false);
 			if (job is null)
 			{
@@ -1388,7 +1396,7 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 				.ConfigureAwait(false);
 			var removed = await Jobs(connection)
 				.Where(item => item.Id == jobId &&
-					(item.State == JobState.Succeeded || item.State == JobState.Failed || item.State == JobState.Cancelled))
+					(item.State == JobState.Succeeded || item.State == JobState.Failed || item.State == JobState.Cancelled || item.State == JobState.Skipped))
 				.DeleteAsync(cancellationToken)
 				.ConfigureAwait(false);
 			if (removed == 0)
@@ -1427,7 +1435,7 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 							job.State == JobState.Succeeded
 							&& job.CompletedAt < (now - succeededRetention).UtcTicks
 						) || (
-							(job.State == JobState.Failed || job.State == JobState.Cancelled)
+							(job.State == JobState.Failed || job.State == JobState.Cancelled || job.State == JobState.Skipped)
 							&& job.CompletedAt < (now - failedRetention).UtcTicks
 						)
 					)
@@ -1901,9 +1909,9 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 					child.FailedDependencies++;
 				if (child.RemainingDependencies == 0)
 				{
-					if (await ShouldCancelSettledContinuationAsync(connection, child.Id, cancellationToken).ConfigureAwait(false))
+					if (await ShouldSkipSettledContinuationAsync(connection, child.Id, cancellationToken).ConfigureAwait(false))
 					{
-						child.State = JobState.Cancelled;
+						child.State = JobState.Skipped;
 						child.CompletedAt = now;
 						child.WorkerId = null;
 						child.LeaseExpiresAt = null;
@@ -1925,7 +1933,7 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 		}
 	}
 
-	private async Task<bool> ShouldCancelSettledContinuationAsync(
+	private async Task<bool> ShouldSkipSettledContinuationAsync(
 		DataConnection connection,
 		string childJobId,
 		CancellationToken cancellationToken
@@ -1982,6 +1990,9 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 				break;
 			case JobState.Cancelled:
 				batch.CancelledCount++;
+				break;
+			case JobState.Skipped:
+				batch.SkippedCount++;
 				break;
 			case JobState.AwaitingContinuation:
 			case JobState.AwaitingParameters:
@@ -2101,7 +2112,7 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 				job.FailedDependencies = failedDependencies;
 				if (violated || (remaining == 0 && requiresFailure && failedDependencies == 0))
 				{
-					job.State = JobState.Cancelled;
+					job.State = JobState.Skipped;
 					job.RemainingDependencies = 0;
 					job.CompletedAt = now;
 					changed = true;
@@ -2273,6 +2284,7 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 			.Set(entity => entity.SucceededCount, batch.SucceededCount)
 			.Set(entity => entity.FailedCount, batch.FailedCount)
 			.Set(entity => entity.CancelledCount, batch.CancelledCount)
+			.Set(entity => entity.SkippedCount, batch.SkippedCount)
 			.Set(entity => entity.StartedAt, batch.StartedAt)
 			.Set(entity => entity.CompletedAt, batch.CompletedAt)
 			.Set(entity => entity.State, batch.State)
@@ -2331,7 +2343,7 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 		where T : notnull => connection.InsertAsync(entity, schemaName: _schema, token: cancellationToken);
 
 	private static bool IsTerminal(JobState state) =>
-		state is JobState.Succeeded or JobState.Failed or JobState.Cancelled;
+		state is JobState.Succeeded or JobState.Failed or JobState.Cancelled or JobState.Skipped;
 
 	private static ContinuationParentOutcome GetParentOutcome(JobState state) => state switch
 	{
@@ -2342,7 +2354,8 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 		JobState.Scheduled or
 		JobState.Pending or
 		JobState.Active or
-		JobState.Cancelled => ContinuationParentOutcome.Other,
+		JobState.Cancelled or
+		JobState.Skipped => ContinuationParentOutcome.Other,
 		_ => throw new ArgumentOutOfRangeException(nameof(state), state, "Unknown job state."),
 	};
 
@@ -2478,6 +2491,7 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 		batch.SucceededCount,
 		batch.FailedCount,
 		batch.CancelledCount,
+		batch.SkippedCount,
 		batch.PendingCount,
 		FromTicks(batch.CreatedAt),
 		FromTicks(batch.StartedAt),

--- a/src/Immediate.Jobs.LinqToDB/LinqToDBSchemaExtensions.cs
+++ b/src/Immediate.Jobs.LinqToDB/LinqToDBSchemaExtensions.cs
@@ -76,6 +76,7 @@ public static class LinqToDBSchemaExtensions
 			"Id" TEXT NOT NULL CONSTRAINT "PK_immediate_job_batches" PRIMARY KEY,
 			"CreatedAt" INTEGER NOT NULL, "TotalJobs" INTEGER NOT NULL, "PendingCount" INTEGER NOT NULL,
 			"SucceededCount" INTEGER NOT NULL, "FailedCount" INTEGER NOT NULL, "CancelledCount" INTEGER NOT NULL,
+			"SkippedCount" INTEGER NOT NULL,
 			"StartedAt" INTEGER NULL, "CompletedAt" INTEGER NULL, "State" INTEGER NOT NULL,
 			"ConcurrencyStamp" TEXT NOT NULL
 		);

--- a/src/Immediate.Jobs.Redis/RedisJobStorage.cs
+++ b/src/Immediate.Jobs.Redis/RedisJobStorage.cs
@@ -416,6 +416,7 @@ public sealed class RedisJobStorage : IRecurringJobStorage, IDisposable
 		await PurgeStateAsync(JobState.Succeeded, now - succeededRetention, cancellationToken).ConfigureAwait(false);
 		await PurgeStateAsync(JobState.Failed, now - failedRetention, cancellationToken).ConfigureAwait(false);
 		await PurgeStateAsync(JobState.Cancelled, now - failedRetention, cancellationToken).ConfigureAwait(false);
+		await PurgeStateAsync(JobState.Skipped, now - failedRetention, cancellationToken).ConfigureAwait(false);
 	}
 
 	/// <inheritdoc />
@@ -596,7 +597,7 @@ public sealed class RedisJobStorage : IRecurringJobStorage, IDisposable
 				StateKey(job.State),
 				DueKey(job.QueueName),
 				RecurringDueKey,
-				CompletedKey(JobState.Cancelled),
+				CompletedKey(job.State),
 			],
 			jobArguments,
 			cancellationToken
@@ -914,10 +915,10 @@ public sealed class RedisJobStorage : IRecurringJobStorage, IDisposable
 			);
 		}
 
-		if (job.State is not (JobState.Pending or JobState.Scheduled or JobState.Cancelled))
+		if (job.State is not (JobState.Pending or JobState.Scheduled or JobState.Cancelled or JobState.Skipped))
 			throw new ImmediateJobException($"Recurring job '{job.Id}' has invalid state '{job.State}'.");
-		if (job.State == JobState.Cancelled && job.CompletedAt is null)
-			throw new ImmediateJobException($"Cancelled recurring job '{job.Id}' must have a completion time.");
+		if (job.CompletedAt is null && (job.State == JobState.Cancelled || job.State == JobState.Skipped))
+			throw new ImmediateJobException($"Terminal recurring job '{job.Id}' must have a completion time.");
 	}
 
 	private static void ValidateRecurring(RecurringJobSchedule schedule)

--- a/src/Immediate.Jobs.Redis/RedisScripts.cs
+++ b/src/Immediate.Jobs.Redis/RedisScripts.cs
@@ -216,7 +216,7 @@ internal static class RedisScripts
 		if redis.call('EXISTS', KEYS[1]) == 0 then return 0 end
 		local values = redis.call('HMGET', KEYS[1], 'state', 'recurringKey')
 		local state = values[1]
-		if state ~= '5' and state ~= '6' and state ~= '7' then return -1 end
+		if state ~= '5' and state ~= '6' and state ~= '7' and state ~= '8' then return -1 end
 		redis.call('DEL', KEYS[1])
 		redis.call('ZREM', KEYS[2], ARGV[1])
 		redis.call('SREM', ARGV[2] .. 'state:' .. state, ARGV[1])
@@ -341,7 +341,7 @@ internal static class RedisScripts
 			redis.call('SADD', KEYS[5], ARGV[3])
 			if ARGV[5] == '2' or ARGV[5] == '3' then
 				redis.call('ZADD', KEYS[6], ARGV[7], ARGV[6] .. '|' .. ARGV[22] .. '|' .. ARGV[3])
-			elseif ARGV[5] == '7' then
+			elseif ARGV[5] == '7' or ARGV[5] == '8' then
 				redis.call('ZADD', KEYS[8], ARGV[23], ARGV[3])
 			end
 		end

--- a/src/Immediate.Jobs.Shared/IJobStorage.cs
+++ b/src/Immediate.Jobs.Shared/IJobStorage.cs
@@ -104,7 +104,7 @@ public interface IJobStorage : IAsyncDisposable
 
 	/// <summary>Deletes terminal job history older than the supplied retention periods.</summary>
 	/// <param name="succeededRetention">The retention period for successful invocations.</param>
-	/// <param name="failedRetention">The retention period for failed or cancelled invocations.</param>
+	/// <param name="failedRetention">The retention period for failed, cancelled, or skipped invocations.</param>
 	/// <param name="cancellationToken">A token that can cancel the storage operation.</param>
 	/// <returns>A value task that represents the asynchronous purge operation.</returns>
 	ValueTask PurgeJobsAsync(

--- a/src/Immediate.Jobs.Shared/InMemoryJobStorage.cs
+++ b/src/Immediate.Jobs.Shared/InMemoryJobStorage.cs
@@ -933,13 +933,18 @@ public sealed class InMemoryJobStorage(TimeProvider timeProvider) :
 			if (batch.State != BatchState.Executing)
 				throw new ImmediateJobException("Only an executing batch can be cancelled.");
 
-			foreach (var jobId in _jobs.Values
+			var now = timeProvider.GetUtcNow();
+			var jobIds = _jobs.Values
 				.Where(job => string.Equals(job.BatchId, batchId, StringComparison.Ordinal) && !IsTerminal(job.State))
 				.Select(static job => job.Id)
-				.ToArray())
+				.ToArray();
+			foreach (var jobId in jobIds)
 			{
-				TransitionToTerminal(jobId, JobState.Cancelled, error: null, timeProvider.GetUtcNow());
+				TransitionToTerminal(jobId, JobState.Cancelled, error: null, now, propagateContinuations: false);
 			}
+
+			foreach (var jobId in jobIds)
+				ProcessTerminalJob(jobId);
 		}
 
 		return ValueTask.CompletedTask;
@@ -1042,7 +1047,7 @@ public sealed class InMemoryJobStorage(TimeProvider timeProvider) :
 						x.CompletedAt is { } completed
 						&& (
 							(x.State is JobState.Succeeded && completed < now - succeededRetention)
-							|| (x.State is JobState.Failed or JobState.Cancelled && completed < now - failedRetention)
+							|| (x.State is JobState.Failed or JobState.Cancelled or JobState.Skipped && completed < now - failedRetention)
 						)
 				)
 				.Select(static job => job.Id)
@@ -1133,7 +1138,8 @@ public sealed class InMemoryJobStorage(TimeProvider timeProvider) :
 		var succeeded = jobs.Count(static job => job.State == JobState.Succeeded);
 		var failed = jobs.Count(static job => job.State == JobState.Failed);
 		var cancelled = jobs.Count(static job => job.State == JobState.Cancelled);
-		var pending = jobs.Count - succeeded - failed - cancelled;
+		var skipped = jobs.Count(static job => job.State == JobState.Skipped);
+		var pending = jobs.Count - succeeded - failed - cancelled - skipped;
 
 		var expectedState = true switch
 		{
@@ -1149,6 +1155,7 @@ public sealed class InMemoryJobStorage(TimeProvider timeProvider) :
 			batch.SucceededCount != succeeded ||
 			batch.FailedCount != failed ||
 			batch.CancelledCount != cancelled ||
+			batch.SkippedCount != skipped ||
 			batch.State != expectedState ||
 			((pending == 0) != (batch.CompletedAt is not null))
 		)
@@ -1261,7 +1268,8 @@ public sealed class InMemoryJobStorage(TimeProvider timeProvider) :
 			batch.SucceededCount != 0 ||
 			batch.FailedCount != 0 ||
 			batch.CancelledCount != 0 ||
-			jobs.Any(static job => job.State is JobState.Active or JobState.Succeeded or JobState.Failed or JobState.Cancelled))
+			batch.SkippedCount != 0 ||
+			jobs.Any(static job => job.State is JobState.Active or JobState.Succeeded or JobState.Failed or JobState.Cancelled or JobState.Skipped))
 		{
 			return true;
 		}
@@ -1330,7 +1338,8 @@ public sealed class InMemoryJobStorage(TimeProvider timeProvider) :
 		string jobId,
 		JobState terminalState,
 		string? error,
-		DateTimeOffset completedAt
+		DateTimeOffset completedAt,
+		bool propagateContinuations = true
 	)
 	{
 		if (!IsTerminal(terminalState))
@@ -1347,7 +1356,8 @@ public sealed class InMemoryJobStorage(TimeProvider timeProvider) :
 			CompletedAt = completedAt,
 		};
 		UpdateBatchAfterTerminal(job.BatchId, terminalState, completedAt);
-		ProcessTerminalJob(jobId);
+		if (propagateContinuations)
+			ProcessTerminalJob(jobId);
 		RemoveFairQueueCursorWhenBacklogClears(job.QueueName, job.GroupId);
 	}
 
@@ -1377,6 +1387,7 @@ public sealed class InMemoryJobStorage(TimeProvider timeProvider) :
 			SucceededCount = batch.SucceededCount + (state == JobState.Succeeded ? 1 : 0),
 			FailedCount = batch.FailedCount + (state == JobState.Failed ? 1 : 0),
 			CancelledCount = batch.CancelledCount + (state == JobState.Cancelled ? 1 : 0),
+			SkippedCount = batch.SkippedCount + (state == JobState.Skipped ? 1 : 0),
 		};
 		if (pending == 0)
 		{
@@ -1448,7 +1459,7 @@ public sealed class InMemoryJobStorage(TimeProvider timeProvider) :
 			FailedDependencies = failedDependencies,
 		};
 		if (!triggersSatisfied)
-			TransitionToTerminal(child.Id, JobState.Cancelled, error: null, timeProvider.GetUtcNow());
+			TransitionToTerminal(child.Id, JobState.Skipped, error: null, timeProvider.GetUtcNow());
 	}
 
 	private (bool Satisfied, int FailedDependencies) EvaluateIncomingTriggers(string childJobId)
@@ -1559,7 +1570,7 @@ public sealed class InMemoryJobStorage(TimeProvider timeProvider) :
 	}
 
 	private static bool IsTerminal(JobState state) =>
-		state is JobState.Succeeded or JobState.Failed or JobState.Cancelled;
+		state is JobState.Succeeded or JobState.Failed or JobState.Cancelled or JobState.Skipped;
 
 	private static bool IsTerminal(BatchState state) => state is not BatchState.Executing;
 
@@ -1570,6 +1581,7 @@ public sealed class InMemoryJobStorage(TimeProvider timeProvider) :
 		batch.SucceededCount,
 		batch.FailedCount,
 		batch.CancelledCount,
+		batch.SkippedCount,
 		batch.PendingCount,
 		batch.CreatedAt,
 		batch.StartedAt,

--- a/src/Immediate.Jobs.Shared/JobBatchModels.cs
+++ b/src/Immediate.Jobs.Shared/JobBatchModels.cs
@@ -64,10 +64,10 @@ public sealed record BatchHandle
 /// <summary>Determines how a continuation evaluates its parents.</summary>
 public enum ContinuationTrigger
 {
-	/// <summary>Run only when every parent succeeds; otherwise cancel the continuation.</summary>
+	/// <summary>Run only when every parent succeeds; otherwise skip the continuation.</summary>
 	Success,
 
-	/// <summary>Run only when every parent is terminal and at least one parent failed.</summary>
+	/// <summary>Run only when every parent is terminal and at least one parent failed; otherwise skip the continuation.</summary>
 	Failure,
 
 	/// <summary>Run after every parent reaches any terminal state.</summary>
@@ -92,7 +92,7 @@ public enum BatchState
 {
 	/// <summary>At least one member has not reached a terminal state.</summary>
 	Executing,
-	/// <summary>Every member succeeded.</summary>
+	/// <summary>Every executed member succeeded; conditional branches may have been skipped.</summary>
 	Succeeded,
 	/// <summary>At least one member failed.</summary>
 	Failed,
@@ -121,9 +121,12 @@ public sealed record JobBatchRecord
 	/// <summary>Members that exhausted their attempts.</summary>
 	/// <value>The number of failed members.</value>
 	public int FailedCount { get; init; }
-	/// <summary>Members cancelled by an explicit action or dependency violation.</summary>
+	/// <summary>Members cancelled by an explicit action.</summary>
 	/// <value>The number of cancelled members.</value>
 	public int CancelledCount { get; init; }
+	/// <summary>Members skipped because their continuation conditions were not met.</summary>
+	/// <value>The number of skipped members.</value>
+	public int SkippedCount { get; init; }
 	/// <summary>UTC time at which the first member was acquired.</summary>
 	/// <value>The UTC batch-start time, if any member has been acquired.</value>
 	public DateTimeOffset? StartedAt { get; init; }
@@ -204,6 +207,7 @@ public sealed class JobExecutionBuffer
 /// <param name="Succeeded">The number of successful members.</param>
 /// <param name="Failed">The number of failed members.</param>
 /// <param name="Cancelled">The number of cancelled members.</param>
+/// <param name="Skipped">The number of skipped members.</param>
 /// <param name="Remaining">The number of non-terminal members.</param>
 /// <param name="CreatedAt">The UTC batch-creation time.</param>
 /// <param name="StartedAt">The UTC time at which the first member was acquired, if any.</param>
@@ -216,6 +220,7 @@ public sealed record BatchStatus(
 	int Succeeded,
 	int Failed,
 	int Cancelled,
+	int Skipped,
 	int Remaining,
 	DateTimeOffset CreatedAt,
 	DateTimeOffset? StartedAt,

--- a/src/Immediate.Jobs.Shared/JobModels.cs
+++ b/src/Immediate.Jobs.Shared/JobModels.cs
@@ -23,6 +23,8 @@ public enum JobState
 	Failed,
 	/// <summary>The job was cancelled.</summary>
 	Cancelled,
+	/// <summary>The job was not run because a continuation condition or scheduling policy was not met.</summary>
+	Skipped,
 }
 
 /// <summary>A storage-neutral durable job record.</summary>

--- a/src/Immediate.Jobs.Shared/JobSchedulerService.cs
+++ b/src/Immediate.Jobs.Shared/JobSchedulerService.cs
@@ -696,7 +696,7 @@ public sealed partial class JobSchedulerService : BackgroundService
 				cancellationToken
 			).ConfigureAwait(false);
 			if (active.Count != 0 || pending.Count != 0)
-				record = record with { State = JobState.Cancelled, CompletedAt = now };
+				record = record with { State = JobState.Skipped, CompletedAt = now };
 		}
 
 		if (await recurringStorage.MaterializeRecurringAsync(schedule, record, next, cancellationToken).ConfigureAwait(false)

--- a/src/Immediate.Jobs.Shared/SingleServerJobStorage.cs
+++ b/src/Immediate.Jobs.Shared/SingleServerJobStorage.cs
@@ -555,6 +555,7 @@ public sealed class SingleServerJobStorage :
 						SucceededCount = status.Succeeded,
 						FailedCount = status.Failed,
 						CancelledCount = status.Cancelled,
+						SkippedCount = status.Skipped,
 						StartedAt = status.StartedAt,
 						CompletedAt = status.CompletedAt,
 						State = status.State,

--- a/src/Immediate.Jobs.Testing/JobTestHarness.cs
+++ b/src/Immediate.Jobs.Testing/JobTestHarness.cs
@@ -246,17 +246,17 @@ public sealed class JobTestHarness : IAsyncDisposable, IDisposable
 			);
 		}
 
-		if (childStatus.State == JobState.Cancelled)
-			throw new JobTestAssertionException($"Expected continuation '{child.Id}' to be released, but it was cancelled.");
+		if (childStatus.State is JobState.Cancelled or JobState.Skipped)
+			throw new JobTestAssertionException($"Expected continuation '{child.Id}' to be released, but it was {childStatus.State}.");
 		if (childStatus.State == JobState.AwaitingContinuation)
 			throw new JobTestAssertionException($"Expected continuation '{child.Id}' to be released, but it is still waiting.");
 	}
 
-	/// <summary>Asserts that every supplied invocation was cancelled by a dependency cascade.</summary>
-	/// <param name="subtree">The invocations expected to be cascade-cancelled.</param>
+	/// <summary>Asserts that every supplied invocation was skipped by a dependency cascade.</summary>
+	/// <param name="subtree">The invocations expected to be cascade-skipped.</param>
 	/// <param name="cancellationToken">A token that can cancel the assertion query.</param>
 	/// <returns>A task that completes when the assertion succeeds.</returns>
-	public async ValueTask AssertCascadeCancelledAsync(
+	public async ValueTask AssertCascadeSkippedAsync(
 		IReadOnlyCollection<JobHandle> subtree,
 		CancellationToken cancellationToken = default
 	)
@@ -265,10 +265,19 @@ public sealed class JobTestHarness : IAsyncDisposable, IDisposable
 		foreach (var handle in subtree)
 		{
 			var job = await GetJobAsync(handle, cancellationToken).ConfigureAwait(false);
-			if (job.State != JobState.Cancelled)
-				throw new JobTestAssertionException($"Expected job '{handle.Id}' to be cascade-cancelled, but it was {job.State}.");
+			if (job.State != JobState.Skipped)
+				throw new JobTestAssertionException($"Expected job '{handle.Id}' to be cascade-skipped, but it was {job.State}.");
 		}
 	}
+
+	/// <summary>Compatibility alias for <see cref="AssertCascadeSkippedAsync"/>.</summary>
+	/// <param name="subtree">The invocations expected to be cascade-skipped.</param>
+	/// <param name="cancellationToken">A token that can cancel the assertion query.</param>
+	/// <returns>A task that completes when the assertion succeeds.</returns>
+	public ValueTask AssertCascadeCancelledAsync(
+		IReadOnlyCollection<JobHandle> subtree,
+		CancellationToken cancellationToken = default
+	) => AssertCascadeSkippedAsync(subtree, cancellationToken);
 
 	/// <summary>Runs one generated invoker, including its compile-time behavior pipeline, outside durable state.</summary>
 	/// <typeparam name="TPayload">The payload type accepted by the generated invoker.</typeparam>

--- a/tests/Immediate.Jobs.FunctionalTests/BatchesAndContinuationsTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/BatchesAndContinuationsTests.cs
@@ -225,7 +225,40 @@ public sealed class BatchesAndContinuationsTests
 	}
 
 	[Fact]
-	public async Task FailedParentCancelsSuccessChildButReleasesFailureAndCompleteChildren()
+	public async Task SuccessfulBatchSkipsFailureBranchAndStillSucceeds()
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		var state = new BatchWorkflowState();
+		await using var harness = CreateHarness(state);
+		await using var scope = harness.Services.CreateAsyncScope();
+		var batches = scope.ServiceProvider.GetRequiredService<IJobBatchScheduler>();
+		var monitor = scope.ServiceProvider.GetRequiredService<IJobBatchMonitor>();
+		var scheduler = scope.ServiceProvider.GetRequiredService<BatchWorkflowJob.Scheduler>();
+		await using var batch = batches.Begin();
+
+		var parent = scheduler.AddToBatch(batch, new("parent"));
+		var failureOnly = await scheduler.ScheduleAfterAsync(
+			parent,
+			new("failure-only"),
+			ContinuationTrigger.Failure,
+			cancellationToken: cancellationToken
+		);
+		var batchHandle = await batch.CommitAsync(cancellationToken);
+
+		await harness.DrainAsync(cancellationToken);
+
+		Assert.Equal(JobState.Succeeded, (await harness.GetJobAsync(parent.Id, cancellationToken)).State);
+		Assert.Equal(JobState.Skipped, (await harness.GetJobAsync(failureOnly.Id, cancellationToken)).State);
+		var status = Assert.IsType<BatchStatus>(await monitor.GetStatusAsync(batchHandle.Id, cancellationToken));
+		Assert.Equal(BatchState.Succeeded, status.State);
+		Assert.Equal(1, status.Succeeded);
+		Assert.Equal(1, status.Skipped);
+		Assert.Equal(0, status.Cancelled);
+		Assert.Equal(["parent"], state.Events);
+	}
+
+	[Fact]
+	public async Task FailedParentSkipsSuccessChildButReleasesFailureAndCompleteChildren()
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;
 		var state = new BatchWorkflowState();
@@ -257,7 +290,7 @@ public sealed class BatchesAndContinuationsTests
 		await harness.DrainAsync(cancellationToken);
 
 		Assert.Equal(JobState.Failed, (await harness.GetJobAsync(parent.Id, cancellationToken)).State);
-		Assert.Equal(JobState.Cancelled, (await harness.GetJobAsync(successOnly.Id, cancellationToken)).State);
+		Assert.Equal(JobState.Skipped, (await harness.GetJobAsync(successOnly.Id, cancellationToken)).State);
 		Assert.Equal(JobState.Succeeded, (await harness.GetJobAsync(failureOnly.Id, cancellationToken)).State);
 		Assert.Equal(JobState.Succeeded, (await harness.GetJobAsync(always.Id, cancellationToken)).State);
 		Assert.Equal(["always", "failure-only", "parent"], state.Events.Order(StringComparer.Ordinal));
@@ -305,7 +338,7 @@ public sealed class BatchesAndContinuationsTests
 			BatchState.Failed,
 			(await graphStorage.GetBatchStatusAsync(batchHandle.Id, cancellationToken))!.State
 		);
-		Assert.Equal(JobState.Cancelled, (await harness.GetJobAsync(successOnly, cancellationToken)).State);
+		Assert.Equal(JobState.Skipped, (await harness.GetJobAsync(successOnly, cancellationToken)).State);
 		Assert.Equal(JobState.Succeeded, (await harness.GetJobAsync(failureOnly, cancellationToken)).State);
 		Assert.Equal(JobState.Succeeded, (await harness.GetJobAsync(always, cancellationToken)).State);
 		Assert.Equal(["batch-complete", "batch-failure", "batch-parent"], state.Events.Order(StringComparer.Ordinal));

--- a/tests/Immediate.Jobs.FunctionalTests/Packages/TestingPackageTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/Packages/TestingPackageTests.cs
@@ -167,7 +167,7 @@ public sealed class TestingPackageTests
 	}
 
 	[Fact]
-	public async Task ContinuationReleaseAssertionRejectsCancellation()
+	public async Task ContinuationReleaseAssertionRejectsSkippedBranch()
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;
 		await using var harness = new JobTestHarness();
@@ -204,7 +204,7 @@ public sealed class TestingPackageTests
 		var exception = await Assert.ThrowsAsync<JobTestAssertionException>(
 			() => harness.AssertContinuationReleasedAfterAsync(new(parent.Id), new(child.Id), cancellationToken).AsTask()
 		);
-		Assert.Contains("cancelled", exception.Message, StringComparison.OrdinalIgnoreCase);
+		Assert.Contains("Skipped", exception.Message, StringComparison.Ordinal);
 	}
 
 	public sealed record TestPayload(string Value);

--- a/tests/Immediate.Jobs.FunctionalTests/RecurringSchedulerTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/RecurringSchedulerTests.cs
@@ -45,7 +45,7 @@ public sealed class RecurringSchedulerTests
 			cancellationToken
 		);
 		var occurrence = Assert.Single(materialized, job => job.RecurringKey is not null);
-		Assert.Equal(JobState.Cancelled, occurrence.State);
+		Assert.Equal(JobState.Skipped, occurrence.State);
 	}
 
 	[Fact]
@@ -67,7 +67,7 @@ public sealed class RecurringSchedulerTests
 			cancellationToken
 		);
 		var occurrence = Assert.Single(jobs, job => job.DueAt == Start.AddHours(1));
-		Assert.Equal(JobState.Cancelled, occurrence.State);
+		Assert.Equal(JobState.Skipped, occurrence.State);
 	}
 
 	[Fact]

--- a/tests/Immediate.Jobs.FunctionalTests/Storage/EntityFrameworkCoreJobStorageTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/Storage/EntityFrameworkCoreJobStorageTests.cs
@@ -685,7 +685,7 @@ public sealed class EntityFrameworkCoreJobStorageTests
 
 	[Theory]
 	[InlineData(true, JobState.Pending)]
-	[InlineData(false, JobState.Cancelled)]
+	[InlineData(false, JobState.Skipped)]
 	public async Task EntityFrameworkCoreFailureContinuationRunsOnlyWhenParentFails(
 		bool parentFails,
 		JobState expectedState
@@ -814,7 +814,7 @@ public sealed class EntityFrameworkCoreJobStorageTests
 		Assert.Equal(JobState.AwaitingContinuation, (await storage.GetJobStatusAsync(child.Id, cancellationToken))!.State);
 		await storage.CompleteAsync(second, "mixed-worker", cancellationToken);
 
-		Assert.Equal(JobState.Cancelled, (await storage.GetJobStatusAsync(child.Id, cancellationToken))!.State);
+		Assert.Equal(JobState.Skipped, (await storage.GetJobStatusAsync(child.Id, cancellationToken))!.State);
 	}
 
 	[Theory]
@@ -1138,7 +1138,7 @@ public sealed class EntityFrameworkCoreJobStorageTests
 		{
 			await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
 			_ = await context.Database.ExecuteSqlAsync(
-				$"""INSERT INTO immediate_job_batches (Id, CreatedAt, TotalJobs, PendingCount, SucceededCount, FailedCount, CancelledCount, StartedAt, CompletedAt, State, ConcurrencyStamp) VALUES ({batchId}, {createdAt.UtcTicks}, 0, 0, 0, 0, 0, NULL, {createdAt.UtcTicks}, {(short)BatchState.Succeeded}, {Guid.NewGuid()})""",
+				$"""INSERT INTO immediate_job_batches (Id, CreatedAt, TotalJobs, PendingCount, SucceededCount, FailedCount, CancelledCount, SkippedCount, StartedAt, CompletedAt, State, ConcurrencyStamp) VALUES ({batchId}, {createdAt.UtcTicks}, 0, 0, 0, 0, 0, 0, NULL, {createdAt.UtcTicks}, {(short)BatchState.Succeeded}, {Guid.NewGuid()})""",
 				cancellationToken
 			);
 		}

--- a/tests/Immediate.Jobs.FunctionalTests/Storage/InMemoryJobStorageBatchTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/Storage/InMemoryJobStorageBatchTests.cs
@@ -136,7 +136,7 @@ public sealed class InMemoryJobStorageBatchTests
 			[new() { ChildJobId = successOnly.Id, ParentJobId = parent.Id }],
 			cancellationToken
 		);
-		Assert.Equal(JobState.Cancelled, (await GetJobAsync(storage, successOnly.Id, cancellationToken)).State);
+		Assert.Equal(JobState.Skipped, (await GetJobAsync(storage, successOnly.Id, cancellationToken)).State);
 
 		var always = CreateJob("always") with
 		{
@@ -176,7 +176,7 @@ public sealed class InMemoryJobStorageBatchTests
 	}
 
 	[Fact]
-	public async Task FailureContinuationIsCancelledWhenEveryParentSucceeds()
+	public async Task FailureContinuationIsSkippedWhenEveryParentSucceeds()
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;
 		await using var storage = new InMemoryJobStorage(new FakeTimeProvider(DateTimeOffset.UnixEpoch));
@@ -201,7 +201,7 @@ public sealed class InMemoryJobStorageBatchTests
 
 		await storage.CompleteAsync(parent.Id, "worker", cancellationToken);
 
-		Assert.Equal(JobState.Cancelled, (await GetJobAsync(storage, child.Id, cancellationToken)).State);
+		Assert.Equal(JobState.Skipped, (await GetJobAsync(storage, child.Id, cancellationToken)).State);
 	}
 
 	[Fact]
@@ -255,8 +255,8 @@ public sealed class InMemoryJobStorageBatchTests
 	}
 
 	[Theory]
-	[InlineData(false, false, JobState.Cancelled)]
-	[InlineData(false, true, JobState.Cancelled)]
+	[InlineData(false, false, JobState.Skipped)]
+	[InlineData(false, true, JobState.Skipped)]
 	[InlineData(true, false, JobState.Pending)]
 	[InlineData(true, true, JobState.Pending)]
 	public async Task MixedTriggersUseAllIncomingEdgesRegardlessOfCompletionOrder(

--- a/tests/Immediate.Jobs.StorageTests/LinqToDBSqliteStorageTests.cs
+++ b/tests/Immediate.Jobs.StorageTests/LinqToDBSqliteStorageTests.cs
@@ -180,8 +180,8 @@ public sealed class LinqToDBSqliteStorageTests
 			_ = await connection.ExecuteAsync(
 				$"""
 				INSERT INTO "immediate_job_batches"
-				("Id", "CreatedAt", "TotalJobs", "PendingCount", "SucceededCount", "FailedCount", "CancelledCount", "State", "ConcurrencyStamp")
-				VALUES ('empty', 0, 0, 0, 0, 0, 0, {(int)BatchState.Succeeded}, '{Guid.NewGuid()}')
+				("Id", "CreatedAt", "TotalJobs", "PendingCount", "SucceededCount", "FailedCount", "CancelledCount", "SkippedCount", "State", "ConcurrencyStamp")
+				VALUES ('empty', 0, 0, 0, 0, 0, 0, 0, {(int)BatchState.Succeeded}, '{Guid.NewGuid()}')
 				""",
 				cancellationToken
 			);
@@ -542,8 +542,8 @@ public sealed class LinqToDBSqliteStorageTests
 
 	[Theory]
 	[InlineData(ContinuationTrigger.Success, true, JobState.Pending)]
-	[InlineData(ContinuationTrigger.Success, false, JobState.Cancelled)]
-	[InlineData(ContinuationTrigger.Failure, true, JobState.Cancelled)]
+	[InlineData(ContinuationTrigger.Success, false, JobState.Skipped)]
+	[InlineData(ContinuationTrigger.Failure, true, JobState.Skipped)]
 	[InlineData(ContinuationTrigger.Failure, false, JobState.Pending)]
 	[InlineData(ContinuationTrigger.Complete, true, JobState.Pending)]
 	[InlineData(ContinuationTrigger.Complete, false, JobState.Pending)]
@@ -580,8 +580,8 @@ public sealed class LinqToDBSqliteStorageTests
 	}
 
 	[Theory]
-	[InlineData(true, false, JobState.Cancelled)]
-	[InlineData(false, false, JobState.Cancelled)]
+	[InlineData(true, false, JobState.Skipped)]
+	[InlineData(false, false, JobState.Skipped)]
 	[InlineData(true, true, JobState.Pending)]
 	[InlineData(false, true, JobState.Pending)]
 	public async Task MixedTriggersUseEveryIncomingEdgeRegardlessOfCompletionOrder(

--- a/tests/Immediate.Jobs.StorageTests/RedisStorageTests.cs
+++ b/tests/Immediate.Jobs.StorageTests/RedisStorageTests.cs
@@ -641,7 +641,7 @@ public sealed class RedisStorageTests(RedisStorageFixture fixture)
 	}
 
 	[Fact]
-	public async Task RecurringMaterializationPersistsSkippedOccurrenceAsCancelled()
+	public async Task RecurringMaterializationPersistsSkippedOccurrenceAsSkipped()
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;
 		await using var connection = await ConnectionMultiplexer.ConnectAsync(fixture.Container.GetConnectionString());
@@ -663,7 +663,7 @@ public sealed class RedisStorageTests(RedisStorageFixture fixture)
 			schedule,
 			CreateJob("skipped", now) with
 			{
-				State = JobState.Cancelled,
+				State = JobState.Skipped,
 				CompletedAt = now,
 				RecurringKey = string.Create(CultureInfo.InvariantCulture, $"{schedule.Name}:{now.UtcTicks}"),
 			},
@@ -671,7 +671,7 @@ public sealed class RedisStorageTests(RedisStorageFixture fixture)
 			cancellationToken
 		));
 		var skipped = Assert.Single(await storage.QueryJobsAsync(
-			new() { State = JobState.Cancelled },
+			new() { State = JobState.Skipped },
 			cancellationToken
 		));
 		Assert.Equal(now, skipped.CompletedAt);

--- a/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
+++ b/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
@@ -609,8 +609,8 @@ public sealed class RelationalStorageMatrixTests(StorageContainers containers)
 		var now = fixture.TimeProvider.GetUtcNow();
 		var scenarios = new[]
 		{
-			(FailureParentSettlesFirst: true, FailureParentFails: false, ExpectedState: JobState.Cancelled),
-			(FailureParentSettlesFirst: false, FailureParentFails: false, ExpectedState: JobState.Cancelled),
+			(FailureParentSettlesFirst: true, FailureParentFails: false, ExpectedState: JobState.Skipped),
+			(FailureParentSettlesFirst: false, FailureParentFails: false, ExpectedState: JobState.Skipped),
 			(FailureParentSettlesFirst: true, FailureParentFails: true, ExpectedState: JobState.Pending),
 			(FailureParentSettlesFirst: false, FailureParentFails: true, ExpectedState: JobState.Pending),
 		};
@@ -935,6 +935,50 @@ public sealed class RelationalStorageMatrixTests(StorageContainers containers)
 
 	[Theory]
 	[MemberData(nameof(Matrix))]
+	public async Task SkippedFailureBranchDoesNotCancelSuccessfulBatch(
+		DatabaseKind database,
+		AdapterKind adapter
+	)
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var fixture = await CreateFixtureAsync(database, adapter, cancellationToken);
+		var storage = fixture.GraphStorage;
+		var now = fixture.TimeProvider.GetUtcNow();
+		var parent = CreateJob("successful-parent", now) with { BatchId = "skipped-branch-batch" };
+		var failureOnly = CreateJob("failure-only", now) with
+		{
+			BatchId = "skipped-branch-batch",
+			State = JobState.AwaitingContinuation,
+			RemainingDependencies = 1,
+		};
+		await storage.EnqueueBatchAsync(new()
+		{
+			Id = "skipped-branch-batch",
+			CreatedAt = now,
+			TotalJobs = 2,
+			PendingCount = 2,
+			State = BatchState.Executing,
+		}, [parent, failureOnly], [new()
+		{
+			ChildJobId = failureOnly.Id,
+			ParentJobId = parent.Id,
+			Trigger = ContinuationTrigger.Failure,
+		}], cancellationToken);
+		_ = Assert.Single(await storage.AcquireDueJobsAsync(CreateRequest("worker", 1), cancellationToken));
+
+		await storage.CompleteAsync(parent.Id, "worker", cancellationToken);
+
+		Assert.Equal(JobState.Skipped, (await storage.GetJobStatusAsync(failureOnly.Id, cancellationToken))!.State);
+		var status = Assert.IsType<BatchStatus>(await storage.GetBatchStatusAsync("skipped-branch-batch", cancellationToken));
+		Assert.Equal(BatchState.Succeeded, status.State);
+		Assert.Equal(1, status.Succeeded);
+		Assert.Equal(1, status.Skipped);
+		Assert.Equal(0, status.Cancelled);
+		Assert.Equal(0, status.Remaining);
+	}
+
+	[Theory]
+	[MemberData(nameof(Matrix))]
 	public async Task EmptyBatchProgressIsFullySettled(DatabaseKind database, AdapterKind adapter)
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;
@@ -1208,7 +1252,8 @@ public sealed class RelationalStorageMatrixTests(StorageContainers containers)
 					{Quote("PendingCount")} = 0,
 					{Quote("SucceededCount")} = 0,
 					{Quote("FailedCount")} = 0,
-					{Quote("CancelledCount")} = 0
+					{Quote("CancelledCount")} = 0,
+					{Quote("SkippedCount")} = 0
 				WHERE {Quote("Id")} = '{batchId}'
 				""",
 				cancellationToken


### PR DESCRIPTION
> Stacked on #77. Until #77 merges, GitHub will also show those prerequisite commits; the diff will collapse afterward.

## Summary
- add a durable Skipped job state and batch counter across every storage provider
- distinguish unselected continuation branches from explicit cancellation
- surface skipped jobs in dashboard metrics, progress, and workflow graphs
- add an Aspire endpoint that demonstrates one root job with success and failure continuation branches

## Verification
- solution Release build
- dashboard lint, typecheck, and 22 tests
- focused continuation and recurring-overlap regressions
- 176 Redis and relational storage tests

Part of #79.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a distinct **Skipped** job state for continuation branches that do not meet trigger conditions.
  - Batches now report skipped jobs separately from cancelled jobs.
  - Added a continuation-branch demonstration endpoint with success and failure scenarios.

- **Dashboard**
  - Progress bars, job tables, workflow views, and summaries now display skipped jobs.

- **Bug Fixes**
  - Recurring jobs skipped due to overlap are recorded consistently.
  - Missing recurring schedules now produce an error when pausing or resuming.

- **Documentation**
  - Updated guides and samples to explain skipped branches and demonstrate the new endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->