### PR TITLE
Add job cancellation APIs and dashboard action

### DIFF
--- a/docs/batches-and-continuations.md
+++ b/docs/batches-and-continuations.md
@@ -691,6 +691,7 @@ for a job with a `Payload` request):
     ValueTask<JobHandle> EnqueueAsync(Payload payload, CancellationToken ct = default);
     ValueTask<JobHandle> ScheduleAsync(Payload payload, TimeSpan delay, CancellationToken ct = default);
     ValueTask<JobHandle> ScheduleAtAsync(Payload payload, DateTimeOffset runAt, CancellationToken ct = default);
+    ValueTask CancelAsync(JobHandle handle, CancellationToken ct = default);
 
     // batch membership (root member, no dependency)
     JobHandle AddToBatch(JobBatch batch, Payload payload, TimeSpan? delay = null);
@@ -722,6 +723,7 @@ Batch and handle types:
 ```csharp
 public interface IJobBatchScheduler
 {
+    ValueTask CancelAsync(BatchHandle handle, CancellationToken ct = default);
     JobBatch Begin();
     JobBatch Begin(BatchHandle after, ContinuationTrigger on = ContinuationTrigger.Success);
     ValueTask<BatchHandle> RunAsync(Func<JobBatch, ValueTask> build, CancellationToken ct = default);

--- a/docs/monitoring-api.md
+++ b/docs/monitoring-api.md
@@ -21,9 +21,8 @@ Call `services.AddImmediateJobsDashboard()` before building the application, the
 | `GET` | `/api/recurring` | All code-defined and dynamic recurring schedules |
 | `GET` | `/api/servers` | Scheduler-node heartbeat snapshots |
 | `GET` | `/api/events` | Server-Sent Events snapshot stream |
-| `POST` | `/api/jobs/{id}/cancel` | Cancel a non-terminal invocation |
+| `POST` | `/api/jobs/{id}` | Cancel a non-terminal invocation |
 | `POST` | `/api/jobs/{id}/retry` | Move a failed invocation to pending |
-| `DELETE` | `/api/jobs/{id}` | Delete a terminal invocation |
 | `POST` | `/api/recurring/{name}/trigger` | Enqueue one immediate invocation for a schedule |
 | `POST` | `/api/recurring/{name}/pause` | Pause future scheduled occurrences |
 | `POST` | `/api/recurring/{name}/resume` | Resume future scheduled occurrences |

--- a/docs/monitoring-api.md
+++ b/docs/monitoring-api.md
@@ -21,6 +21,7 @@ Call `services.AddImmediateJobsDashboard()` before building the application, the
 | `GET` | `/api/recurring` | All code-defined and dynamic recurring schedules |
 | `GET` | `/api/servers` | Scheduler-node heartbeat snapshots |
 | `GET` | `/api/events` | Server-Sent Events snapshot stream |
+| `POST` | `/api/jobs/{id}/cancel` | Cancel a non-terminal invocation |
 | `POST` | `/api/jobs/{id}/retry` | Move a failed invocation to pending |
 | `DELETE` | `/api/jobs/{id}` | Delete a terminal invocation |
 | `POST` | `/api/recurring/{name}/trigger` | Enqueue one immediate invocation for a schedule |

--- a/docs/monitoring-api.md
+++ b/docs/monitoring-api.md
@@ -21,7 +21,7 @@ Call `services.AddImmediateJobsDashboard()` before building the application, the
 | `GET` | `/api/recurring` | All code-defined and dynamic recurring schedules |
 | `GET` | `/api/servers` | Scheduler-node heartbeat snapshots |
 | `GET` | `/api/events` | Server-Sent Events snapshot stream |
-| `POST` | `/api/jobs/{id}` | Cancel a non-terminal invocation |
+| `POST` | `/api/jobs/{id}/cancel` | Cancel a non-terminal invocation |
 | `POST` | `/api/jobs/{id}/retry` | Move a failed invocation to pending |
 | `POST` | `/api/recurring/{name}/trigger` | Enqueue one immediate invocation for a schedule |
 | `POST` | `/api/recurring/{name}/pause` | Pause future scheduled occurrences |

--- a/docs/storage-capabilities.md
+++ b/docs/storage-capabilities.md
@@ -44,7 +44,7 @@ each `: IJobStorage`.
 
 **`IJobStorage`** (the required base = the queue capability):
 `InitializeAsync`, `EnqueueAsync`, `AcquireDueJobsAsync`, `RenewLeaseAsync`, `CompleteAsync`,
-`FailAsync`, `RetryAsync`, `DeleteAsync`, `HeartbeatAsync`, `IsHealthyAsync`, `QueryJobsAsync`,
+`FailAsync`, `CancelAsync`, `RetryAsync`, `DeleteAsync`, `HeartbeatAsync`, `IsHealthyAsync`, `QueryJobsAsync`,
 `GetJobStatusAsync`, `GetMonitoringSnapshotAsync`, and a job-history slice of `PurgeAsync` (see §3.3).
 
 **`IRecurringJobStorage`:**

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,17 @@ public sealed class SignupService(SendWelcomeEmail.Scheduler welcomeEmail)
 string invocation ID. Consumers must not parse it or depend on its format; storage integrations may
 use another string ID scheme.
 
+Use the same generated scheduler to cancel a non-terminal invocation:
+
+```csharp
+JobHandle handle = await scheduler.EnqueueAsync(new(importId), cancellationToken);
+await scheduler.CancelAsync(handle, cancellationToken);
+```
+
+Cancellation immediately records the durable job as `Cancelled`. If a worker already owns it, the
+current in-process handler is not forcibly interrupted, but its stale completion cannot overwrite the
+cancelled state.
+
 ## Register Jobs and Execution Engine
 
 In your `Program.cs`, add a call to `services.AddXxxJobs()`, where `Xxx` is the application identifier.
@@ -83,6 +94,12 @@ await finalize.ScheduleAfterAsync(
 );
 
 BatchHandle committed = await batch.CommitAsync(cancellationToken);
+```
+
+Cancel every non-terminal member through the same batch scheduler:
+
+```csharp
+await batches.CancelAsync(committed, cancellationToken);
 ```
 
 `ContinuationTrigger.Success` is the default; `Failure` runs after every parent settles when at

--- a/spec.md
+++ b/spec.md
@@ -319,7 +319,7 @@ Grouped by concern:
 - **Reads (dashboard/monitoring):** `GetMonitoringSnapshotAsync`, `QueryJobsAsync`,
   `QueryJobExecutionsAsync`, `GetJobStatusAsync`, `QueryBatchesAsync`, `QueryBatchMembersAsync`,
   `GetBatchStatusAsync`, `GetBatchGraphAsync`.
-- **Maintenance & health:** `RetryAsync`, `DeleteAsync`, `PurgeAsync(retention)`, `HeartbeatAsync`,
+- **Maintenance & health:** `CancelAsync`, `RetryAsync`, `DeleteAsync`, `PurgeAsync(retention)`, `HeartbeatAsync`,
   `IsHealthyAsync`, `InitializeAsync`.
 
 Single-server mode additionally uses the small `IJobStorageReplica` capability to mirror the exact set

--- a/src/Immediate.Jobs.Dashboard/DashboardApiEndpoints.cs
+++ b/src/Immediate.Jobs.Dashboard/DashboardApiEndpoints.cs
@@ -489,7 +489,7 @@ internal static partial class RetryDashboardJob
 }
 
 [Handler]
-[MapPost("jobs/{jobId}")]
+[MapPost("jobs/{jobId}/cancel")]
 [MapGroup<DashboardApi>]
 internal static partial class CancelDashboardJob
 {

--- a/src/Immediate.Jobs.Dashboard/DashboardApiEndpoints.cs
+++ b/src/Immediate.Jobs.Dashboard/DashboardApiEndpoints.cs
@@ -489,6 +489,28 @@ internal static partial class RetryDashboardJob
 }
 
 [Handler]
+[MapPost("jobs/{jobId}/cancel")]
+[MapGroup<DashboardApi>]
+internal static partial class CancelDashboardJob
+{
+	[Validate]
+	internal sealed partial record Command : IValidationTarget<Command>
+	{
+		[FromRoute]
+		[NotEmpty]
+		public required string JobId { get; init; }
+	}
+
+	private static ValueTask<IResult> HandleAsync(
+		Command command,
+		IJobStorage storage,
+		CancellationToken cancellationToken
+	) => DashboardApiEndpointOperations.MutateJobAsync(
+		() => storage.CancelAsync(command.JobId, cancellationToken)
+	);
+}
+
+[Handler]
 [MapDelete("jobs/{jobId}")]
 [MapGroup<DashboardApi>]
 internal static partial class DeleteDashboardJob

--- a/src/Immediate.Jobs.Dashboard/DashboardApiEndpoints.cs
+++ b/src/Immediate.Jobs.Dashboard/DashboardApiEndpoints.cs
@@ -489,7 +489,7 @@ internal static partial class RetryDashboardJob
 }
 
 [Handler]
-[MapPost("jobs/{jobId}/cancel")]
+[MapPost("jobs/{jobId}")]
 [MapGroup<DashboardApi>]
 internal static partial class CancelDashboardJob
 {
@@ -507,27 +507,6 @@ internal static partial class CancelDashboardJob
 		CancellationToken cancellationToken
 	) => DashboardApiEndpointOperations.MutateJobAsync(
 		() => storage.CancelAsync(command.JobId, cancellationToken)
-	);
-}
-
-[Handler]
-[MapDelete("jobs/{jobId}")]
-[MapGroup<DashboardApi>]
-internal static partial class DeleteDashboardJob
-{
-	[Validate]
-	internal sealed partial record Command : IValidationTarget<Command>
-	{
-		[NotEmpty]
-		public required string JobId { get; init; }
-	}
-
-	private static ValueTask<IResult> HandleAsync(
-		Command command,
-		IJobStorage storage,
-		CancellationToken cancellationToken
-	) => DashboardApiEndpointOperations.MutateJobAsync(
-		() => storage.DeleteAsync(command.JobId, cancellationToken)
 	);
 }
 

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/src/api.ts
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/src/api.ts
@@ -138,11 +138,7 @@ export function retryJob(jobId: string): Promise<void> {
 }
 
 export function cancelJob(jobId: string): Promise<void> {
-	return request(`jobs/${encodeURIComponent(jobId)}/cancel`, { method: 'POST' });
-}
-
-export function deleteJob(jobId: string): Promise<void> {
-	return request(`jobs/${encodeURIComponent(jobId)}`, { method: 'DELETE' });
+	return request(`jobs/${encodeURIComponent(jobId)}`, { method: 'POST' });
 }
 
 export function cancelBatch(batchId: string): Promise<void> {

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/src/api.ts
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/src/api.ts
@@ -137,6 +137,10 @@ export function retryJob(jobId: string): Promise<void> {
 	return request(`jobs/${encodeURIComponent(jobId)}/retry`, { method: 'POST' });
 }
 
+export function cancelJob(jobId: string): Promise<void> {
+	return request(`jobs/${encodeURIComponent(jobId)}/cancel`, { method: 'POST' });
+}
+
 export function deleteJob(jobId: string): Promise<void> {
 	return request(`jobs/${encodeURIComponent(jobId)}`, { method: 'DELETE' });
 }

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/src/api.ts
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/src/api.ts
@@ -138,7 +138,7 @@ export function retryJob(jobId: string): Promise<void> {
 }
 
 export function cancelJob(jobId: string): Promise<void> {
-	return request(`jobs/${encodeURIComponent(jobId)}`, { method: 'POST' });
+	return request(`jobs/${encodeURIComponent(jobId)}/cancel`, { method: 'POST' });
 }
 
 export function cancelBatch(batchId: string): Promise<void> {

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/src/components/JobDetail.vue
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/src/components/JobDetail.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { onBeforeUnmount, ref, watch } from 'vue';
-import { Activity, Check, ChevronDown, Copy, ExternalLink, RotateCcw, ScrollText, X } from '@lucide/vue';
+import { Activity, Ban, Check, ChevronDown, Copy, ExternalLink, RotateCcw, ScrollText, X } from '@lucide/vue';
 
 import StateBadge from '@/components/StateBadge.vue';
 import { getJobExecutions, getJobExecutionTelemetryLinks } from '@/api';
 import {
+	canCancelJob,
 	canRetryJob,
 	type JobExecutionRecord,
 	type JobRecord,
@@ -24,6 +25,7 @@ const props = withDefaults(defineProps<{
 });
 
 const emit = defineEmits<{
+	cancel: [job: JobRecord];
 	close: [];
 	retry: [job: JobRecord];
 }>();
@@ -174,16 +176,28 @@ function retryButtonLabel(job: JobRecord, pending: boolean): string {
 		<div class="inspector-content">
 			<div class="flex items-center justify-between gap-3">
 				<StateBadge :state="job.state" />
-				<button
-					v-if="canRetryJob(job)"
-					class="button button-secondary"
-					type="button"
-					:disabled="pending"
-					@click="emit('retry', job)"
-				>
-					<RotateCcw :size="14" aria-hidden="true" />
-					{{ retryButtonLabel(job, pending) }}
-				</button>
+				<div class="flex items-center gap-2">
+					<button
+						v-if="canCancelJob(job)"
+						class="button button-secondary danger-text"
+						type="button"
+						:disabled="pending"
+						@click="emit('cancel', job)"
+					>
+						<Ban :size="14" aria-hidden="true" />
+						Cancel job
+					</button>
+					<button
+						v-if="canRetryJob(job)"
+						class="button button-secondary"
+						type="button"
+						:disabled="pending"
+						@click="emit('retry', job)"
+					>
+						<RotateCcw :size="14" aria-hidden="true" />
+						{{ retryButtonLabel(job, pending) }}
+					</button>
+				</div>
 			</div>
 
 			<dl class="detail-list">

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/src/components/JobTable.vue
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/src/components/JobTable.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { Eye, Layers3, RotateCcw, Trash2 } from '@lucide/vue';
+import { Ban, Eye, Layers3, RotateCcw, Trash2 } from '@lucide/vue';
 
 import FeedbackState from '@/components/FeedbackState.vue';
 import StateBadge from '@/components/StateBadge.vue';
-import { canRetryJob, type JobRecord } from '@/contracts';
+import { canCancelJob, canRetryJob, type JobRecord } from '@/contracts';
 import { formatDate } from '@/format';
 
 withDefaults(defineProps<{
@@ -16,6 +16,7 @@ withDefaults(defineProps<{
 const emit = defineEmits<{
 	select: [job: JobRecord];
 	openBatch: [batchId: string];
+	cancel: [job: JobRecord];
 	retry: [job: JobRecord];
 	delete: [job: JobRecord];
 }>();
@@ -90,6 +91,16 @@ function retryLabel(job: JobRecord): string {
 									@click="emit('retry', job)"
 								>
 									<RotateCcw :size="15" aria-hidden="true" />
+								</button>
+								<button
+									v-if="canCancelJob(job)"
+									class="icon-button danger"
+									type="button"
+									:disabled="busyJobId === job.id"
+									:aria-label="`Cancel ${job.jobName}`"
+									@click="emit('cancel', job)"
+								>
+									<Ban :size="15" aria-hidden="true" />
 								</button>
 								<button
 									v-if="job.state === 'Failed'"

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/src/components/JobTable.vue
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/src/components/JobTable.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Ban, Eye, Layers3, RotateCcw, Trash2 } from '@lucide/vue';
+import { Ban, Eye, Layers3, RotateCcw } from '@lucide/vue';
 
 import FeedbackState from '@/components/FeedbackState.vue';
 import StateBadge from '@/components/StateBadge.vue';
@@ -18,7 +18,6 @@ const emit = defineEmits<{
 	openBatch: [batchId: string];
 	cancel: [job: JobRecord];
 	retry: [job: JobRecord];
-	delete: [job: JobRecord];
 }>();
 
 function retryLabel(job: JobRecord): string {
@@ -101,16 +100,6 @@ function retryLabel(job: JobRecord): string {
 									@click="emit('cancel', job)"
 								>
 									<Ban :size="15" aria-hidden="true" />
-								</button>
-								<button
-									v-if="job.state === 'Failed'"
-									class="icon-button danger"
-									type="button"
-									:disabled="busyJobId === job.id"
-									:aria-label="`Delete ${job.jobName}`"
-									@click="emit('delete', job)"
-								>
-									<Trash2 :size="15" aria-hidden="true" />
 								</button>
 							</div>
 						</td>

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/src/contracts.ts
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/src/contracts.ts
@@ -48,6 +48,13 @@ export function canRetryJob(job: Pick<JobRecord, 'state'>): boolean {
 	return job.state === 'Failed' || job.state === 'Scheduled';
 }
 
+export function canCancelJob(job: Pick<JobRecord, 'state'>): boolean {
+	return job.state !== 'Succeeded'
+		&& job.state !== 'Failed'
+		&& job.state !== 'Cancelled'
+		&& job.state !== 'Skipped';
+}
+
 export interface RecurringJobSchedule {
 	name: string;
 	jobName: string;

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/src/query.ts
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/src/query.ts
@@ -39,6 +39,7 @@ export const queryKeys = {
 	jobs: (filters: JobFilters) => ['jobs', 'page', filters] as const,
 	job: (jobId: string) => ['jobs', 'detail', jobId] as const,
 	jobTelemetryLinks: (jobId: string) => ['jobs', 'telemetry-links', jobId] as const,
+	batchRoot: ['batches'] as const,
 	batches: ['batches', 'list'] as const,
 	batch: (batchId: string) => ['batches', 'detail', batchId] as const,
 	batchGraph: (batchId: string) => ['batches', 'graph', batchId] as const,

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/src/use-dashboard-mutations.ts
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/src/use-dashboard-mutations.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/vue-query';
 
 import {
 	cancelBatch,
+	cancelJob,
 	deleteBatch,
 	deleteJob,
 	retryJob,
@@ -14,6 +15,16 @@ import { queryKeys, refreshDashboardQueries } from '@/query';
 
 export function useJobMutations() {
 	const queryClient = useQueryClient();
+	const cancelMutation = useMutation({
+		mutationFn: cancelJob,
+		onSuccess: async (_, jobId) => {
+			notify('Job cancelled.');
+			await queryClient.invalidateQueries({ queryKey: queryKeys.job(jobId) });
+			await queryClient.invalidateQueries({ queryKey: queryKeys.batchRoot });
+			await refreshDashboardQueries(queryClient);
+		},
+		onError: (reason) => notify(errorText(reason), 'error'),
+	});
 	const retryMutation = useMutation({
 		mutationFn: retryJob,
 		onSuccess: async (_, jobId) => {
@@ -34,14 +45,19 @@ export function useJobMutations() {
 	});
 
 	return {
+		cancelJob: cancelMutation.mutateAsync,
 		retryJob: retryMutation.mutate,
 		deleteJob: deleteMutation.mutateAsync,
 		busyJobId: computed(() => {
+			if (cancelMutation.isPending.value) {
+				return cancelMutation.variables.value;
+			}
 			if (retryMutation.isPending.value) {
 				return retryMutation.variables.value;
 			}
 			return deleteMutation.isPending.value ? deleteMutation.variables.value : undefined;
 		}),
+		cancelling: cancelMutation.isPending,
 		deleting: deleteMutation.isPending,
 	};
 }

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/src/use-dashboard-mutations.ts
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/src/use-dashboard-mutations.ts
@@ -5,7 +5,6 @@ import {
 	cancelBatch,
 	cancelJob,
 	deleteBatch,
-	deleteJob,
 	retryJob,
 	setRecurringPaused,
 	triggerRecurring,
@@ -34,20 +33,9 @@ export function useJobMutations() {
 		},
 		onError: (reason) => notify(errorText(reason), 'error'),
 	});
-	const deleteMutation = useMutation({
-		mutationFn: deleteJob,
-		onSuccess: async (_, jobId) => {
-			notify('Job deleted.');
-			queryClient.removeQueries({ queryKey: queryKeys.job(jobId) });
-			await refreshDashboardQueries(queryClient);
-		},
-		onError: (reason) => notify(errorText(reason), 'error'),
-	});
-
 	return {
 		cancelJob: cancelMutation.mutateAsync,
 		retryJob: retryMutation.mutate,
-		deleteJob: deleteMutation.mutateAsync,
 		busyJobId: computed(() => {
 			if (cancelMutation.isPending.value) {
 				return cancelMutation.variables.value;
@@ -55,10 +43,9 @@ export function useJobMutations() {
 			if (retryMutation.isPending.value) {
 				return retryMutation.variables.value;
 			}
-			return deleteMutation.isPending.value ? deleteMutation.variables.value : undefined;
+			return undefined;
 		}),
 		cancelling: cancelMutation.isPending,
-		deleting: deleteMutation.isPending,
 	};
 }
 

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/src/views/BatchDetailView.vue
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/src/views/BatchDetailView.vue
@@ -9,6 +9,7 @@ import JobDetail from '@/components/JobDetail.vue';
 import PageHeader from '@/components/PageHeader.vue';
 import StateBadge from '@/components/StateBadge.vue';
 import WorkflowGraph from '@/components/WorkflowGraph.vue';
+import type { JobRecord } from '@/contracts';
 import { formatDate } from '@/format';
 import { errorText } from '@/notifications';
 import { useBatchGraphQuery, useBatchQuery, useJobQuery, useJobTelemetryLinksQuery } from '@/query';
@@ -18,6 +19,7 @@ import { useBatchStream } from '@/use-dashboard-stream';
 const route = useRoute();
 const router = useRouter();
 const pendingAction = ref<'cancel' | 'delete'>();
+const jobCancelCandidate = ref<JobRecord>();
 const graphJobDetail = ref<HTMLElement>();
 
 const batchId = computed(() => {
@@ -90,6 +92,18 @@ async function confirmAction(): Promise<void> {
 			await batchMutations.deleteBatch(batchId.value);
 			backToBatches();
 		}
+	} catch {
+		// The mutation displays the API error and leaves the confirmation open.
+	}
+}
+
+async function confirmJobCancel(): Promise<void> {
+	if (!jobCancelCandidate.value) {
+		return;
+	}
+	try {
+		await jobMutations.cancelJob(jobCancelCandidate.value.id);
+		jobCancelCandidate.value = undefined;
 	} catch {
 		// The mutation displays the API error and leaves the confirmation open.
 	}
@@ -185,6 +199,7 @@ async function confirmAction(): Promise<void> {
 							:telemetry-links="telemetryLinksQuery.data.value ?? []"
 							:pending="jobMutations.busyJobId.value === selectedJobId"
 							@close="closeGraphJob"
+							@cancel="jobCancelCandidate = $event"
 							@retry="(job) => jobMutations.retryJob(job.id)"
 						/>
 					</div>
@@ -202,6 +217,16 @@ async function confirmAction(): Promise<void> {
 			:pending="batchMutations.mutating.value"
 			@cancel="pendingAction = undefined"
 			@confirm="confirmAction"
+		/>
+
+		<ConfirmDialog
+			:open="Boolean(jobCancelCandidate)"
+			title="Cancel job?"
+			:description="`This marks ${jobCancelCandidate?.jobName ?? 'this job'} as cancelled. Work already running may finish its current attempt.`"
+			confirm-label="Cancel job"
+			:pending="jobMutations.cancelling.value"
+			@cancel="jobCancelCandidate = undefined"
+			@confirm="confirmJobCancel"
 		/>
 	</section>
 </template>

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/src/views/JobDetailView.vue
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/src/views/JobDetailView.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { ArrowLeft } from '@lucide/vue';
 
+import ConfirmDialog from '@/components/ConfirmDialog.vue';
 import FeedbackState from '@/components/FeedbackState.vue';
 import JobDetail from '@/components/JobDetail.vue';
+import type { JobRecord } from '@/contracts';
 import { errorText } from '@/notifications';
 import { useJobQuery, useJobTelemetryLinksQuery } from '@/query';
 import { useJobMutations } from '@/use-dashboard-mutations';
@@ -18,9 +20,22 @@ const jobId = computed(() => {
 const jobQuery = useJobQuery(jobId);
 const telemetryLinksQuery = useJobTelemetryLinksQuery(jobId);
 const jobMutations = useJobMutations();
+const cancelCandidate = ref<JobRecord>();
 
 function backToJobs(): void {
 	void router.push({ name: 'jobs', query: route.query });
+}
+
+async function confirmCancel(): Promise<void> {
+	if (!cancelCandidate.value) {
+		return;
+	}
+	try {
+		await jobMutations.cancelJob(cancelCandidate.value.id);
+		cancelCandidate.value = undefined;
+	} catch {
+		// The mutation displays the API error and leaves the confirmation open.
+	}
 }
 </script>
 
@@ -49,12 +64,23 @@ function backToJobs(): void {
 			:telemetry-links="telemetryLinksQuery.data.value ?? []"
 			:pending="jobMutations.busyJobId.value === jobId"
 			:show-close="false"
+			@cancel="cancelCandidate = $event"
 			@retry="(job) => jobMutations.retryJob(job.id)"
 		/>
 		<FeedbackState
 			v-else
 			title="Job not found"
 			description="The requested job does not exist."
+		/>
+
+		<ConfirmDialog
+			:open="Boolean(cancelCandidate)"
+			title="Cancel job?"
+			:description="`This marks ${cancelCandidate?.jobName ?? 'this job'} as cancelled. Work already running may finish its current attempt.`"
+			confirm-label="Cancel job"
+			:pending="jobMutations.cancelling.value"
+			@cancel="cancelCandidate = undefined"
+			@confirm="confirmCancel"
 		/>
 	</section>
 </template>

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/src/views/JobsView.vue
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/src/views/JobsView.vue
@@ -22,6 +22,7 @@ const stateQuery = useRouteQuery<string>('state', '');
 const pageQuery = useRouteQuery<string>('page', '1');
 const debouncedSearch = refDebounced(searchQuery, 250);
 const debouncedQueue = refDebounced(queueQuery, 250);
+const cancelCandidate = ref<JobRecord>();
 const deleteCandidate = ref<JobRecord>();
 
 const selectedState = computed<JobState | ''>(() => {
@@ -83,6 +84,18 @@ async function confirmDelete(): Promise<void> {
 		// The mutation displays the API error and leaves the confirmation open.
 	}
 }
+
+async function confirmCancel(): Promise<void> {
+	if (!cancelCandidate.value) {
+		return;
+	}
+	try {
+		await jobMutations.cancelJob(cancelCandidate.value.id);
+		cancelCandidate.value = undefined;
+	} catch {
+		// The mutation displays the API error and leaves the confirmation open.
+	}
+}
 </script>
 
 <template>
@@ -120,6 +133,7 @@ async function confirmDelete(): Promise<void> {
 				:busy-job-id="jobMutations.busyJobId.value"
 				@select="openJob"
 				@open-batch="openBatch"
+				@cancel="cancelCandidate = $event"
 				@retry="(job) => jobMutations.retryJob(job.id)"
 				@delete="deleteCandidate = $event"
 			/>
@@ -135,6 +149,16 @@ async function confirmDelete(): Promise<void> {
 				</button>
 			</div>
 		</div>
+
+		<ConfirmDialog
+			:open="Boolean(cancelCandidate)"
+			title="Cancel job?"
+			:description="`This marks ${cancelCandidate?.jobName ?? 'this job'} as cancelled. Work already running may finish its current attempt.`"
+			confirm-label="Cancel job"
+			:pending="jobMutations.cancelling.value"
+			@cancel="cancelCandidate = undefined"
+			@confirm="confirmCancel"
+		/>
 
 		<ConfirmDialog
 			:open="Boolean(deleteCandidate)"

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/src/views/JobsView.vue
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/src/views/JobsView.vue
@@ -23,7 +23,6 @@ const pageQuery = useRouteQuery<string>('page', '1');
 const debouncedSearch = refDebounced(searchQuery, 250);
 const debouncedQueue = refDebounced(queueQuery, 250);
 const cancelCandidate = ref<JobRecord>();
-const deleteCandidate = ref<JobRecord>();
 
 const selectedState = computed<JobState | ''>(() => {
 	return jobStates.includes(stateQuery.value as JobState) ? stateQuery.value as JobState : '';
@@ -70,19 +69,6 @@ function openBatch(batchId: string): void {
 
 function changePage(nextPage: number): void {
 	pageQuery.value = String(Math.max(1, nextPage));
-}
-
-async function confirmDelete(): Promise<void> {
-	if (!deleteCandidate.value) {
-		return;
-	}
-	const deletedId = deleteCandidate.value.id;
-	try {
-		await jobMutations.deleteJob(deletedId);
-		deleteCandidate.value = undefined;
-	} catch {
-		// The mutation displays the API error and leaves the confirmation open.
-	}
 }
 
 async function confirmCancel(): Promise<void> {
@@ -135,7 +121,6 @@ async function confirmCancel(): Promise<void> {
 				@open-batch="openBatch"
 				@cancel="cancelCandidate = $event"
 				@retry="(job) => jobMutations.retryJob(job.id)"
-				@delete="deleteCandidate = $event"
 			/>
 			<div class="pagination" aria-label="Jobs pagination">
 				<button class="button button-secondary" type="button" :disabled="page === 1" @click="changePage(page - 1)">
@@ -158,16 +143,6 @@ async function confirmCancel(): Promise<void> {
 			:pending="jobMutations.cancelling.value"
 			@cancel="cancelCandidate = undefined"
 			@confirm="confirmCancel"
-		/>
-
-		<ConfirmDialog
-			:open="Boolean(deleteCandidate)"
-			title="Delete failed job?"
-			:description="`This permanently removes ${deleteCandidate?.jobName ?? 'this job'} and its stored payload.`"
-			confirm-label="Delete job"
-			:pending="jobMutations.deleting.value"
-			@cancel="deleteCandidate = undefined"
-			@confirm="confirmDelete"
 		/>
 	</section>
 </template>

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/src/views/OverviewView.vue
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/src/views/OverviewView.vue
@@ -19,7 +19,7 @@ const router = useRouter();
 const overviewQuery = useOverviewQuery();
 const recentJobsQuery = useRecentJobsQuery();
 const jobMutations = useJobMutations();
-const deleteCandidate = ref<JobRecord>();
+const cancelCandidate = ref<JobRecord>();
 
 const summaryStates: JobState[] = [
 	'Pending',
@@ -61,13 +61,13 @@ function openBatch(batchId: string): void {
 	void router.push({ name: 'batch-detail', params: { batchId } });
 }
 
-async function confirmDelete(): Promise<void> {
-	if (!deleteCandidate.value) {
+async function confirmCancel(): Promise<void> {
+	if (!cancelCandidate.value) {
 		return;
 	}
 	try {
-		await jobMutations.deleteJob(deleteCandidate.value.id);
-		deleteCandidate.value = undefined;
+		await jobMutations.cancelJob(cancelCandidate.value.id);
+		cancelCandidate.value = undefined;
 	} catch {
 		// The mutation displays the API error and leaves the confirmation open.
 	}
@@ -118,19 +118,19 @@ async function confirmDelete(): Promise<void> {
 				:busy-job-id="jobMutations.busyJobId.value"
 				@select="openJob"
 				@open-batch="openBatch"
+				@cancel="cancelCandidate = $event"
 				@retry="(job) => jobMutations.retryJob(job.id)"
-				@delete="deleteCandidate = $event"
 			/>
 		</template>
 
 		<ConfirmDialog
-			:open="Boolean(deleteCandidate)"
-			title="Delete failed job?"
-			:description="`This permanently removes ${deleteCandidate?.jobName ?? 'this job'} and its stored payload.`"
-			confirm-label="Delete job"
-			:pending="jobMutations.deleting.value"
-			@cancel="deleteCandidate = undefined"
-			@confirm="confirmDelete"
+			:open="Boolean(cancelCandidate)"
+			title="Cancel job?"
+			:description="`This marks ${cancelCandidate?.jobName ?? 'this job'} as cancelled. Work already running may finish its current attempt.`"
+			confirm-label="Cancel job"
+			:pending="jobMutations.cancelling.value"
+			@cancel="cancelCandidate = undefined"
+			@confirm="confirmCancel"
 		/>
 	</section>
 </template>

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/tests/api.test.ts
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/tests/api.test.ts
@@ -23,7 +23,7 @@ describe('dashboard API client', () => {
 		await cancelJob('job/one');
 
 		const requestedUrl = new URL(String(fetchMock.mock.calls[0]?.[0]));
-		expect(requestedUrl.pathname.endsWith('/api/jobs/job%2Fone')).toBe(true);
+		expect(requestedUrl.pathname.endsWith('/api/jobs/job%2Fone/cancel')).toBe(true);
 		expect(fetchMock.mock.calls[0]?.[1]).toEqual(expect.objectContaining({ method: 'POST' }));
 	});
 

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/tests/api.test.ts
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/tests/api.test.ts
@@ -23,7 +23,7 @@ describe('dashboard API client', () => {
 		await cancelJob('job/one');
 
 		const requestedUrl = new URL(String(fetchMock.mock.calls[0]?.[0]));
-		expect(requestedUrl.pathname).toContain('/api/jobs/job%2Fone/cancel');
+		expect(requestedUrl.pathname.endsWith('/api/jobs/job%2Fone')).toBe(true);
 		expect(fetchMock.mock.calls[0]?.[1]).toEqual(expect.objectContaining({ method: 'POST' }));
 	});
 

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/tests/api.test.ts
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/tests/api.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { ApiError, getJobs, request } from '@/api';
+import { ApiError, cancelJob, getJobs, request } from '@/api';
 
 describe('dashboard API client', () => {
 	it('requests server-side job pages of fifty with encoded filters', async () => {
@@ -15,6 +15,16 @@ describe('dashboard API client', () => {
 		expect(requestedUrl.searchParams.get('search')).toBe('send email');
 		expect(requestedUrl.searchParams.get('queue')).toBe('priority/jobs');
 		expect(requestedUrl.searchParams.get('state')).toBe('Failed');
+	});
+
+	it('cancels jobs through an encoded dashboard route', async () => {
+		const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
+
+		await cancelJob('job/one');
+
+		const requestedUrl = new URL(String(fetchMock.mock.calls[0]?.[0]));
+		expect(requestedUrl.pathname).toContain('/api/jobs/job%2Fone/cancel');
+		expect(fetchMock.mock.calls[0]?.[1]).toEqual(expect.objectContaining({ method: 'POST' }));
 	});
 
 	it('handles empty successful responses and structured problems', async () => {

--- a/src/Immediate.Jobs.Dashboard/DashboardClient/tests/components.test.ts
+++ b/src/Immediate.Jobs.Dashboard/DashboardClient/tests/components.test.ts
@@ -262,9 +262,16 @@ describe('dashboard components', () => {
 		const runNow = table.get('button[aria-label="Run retry-test now"]');
 		await runNow.trigger('click');
 		expect(table.emitted('retry')?.[0]).toEqual([scheduled]);
+		const cancel = table.get('button[aria-label="Cancel retry-test"]');
+		await cancel.trigger('click');
+		expect(table.emitted('cancel')?.[0]).toEqual([scheduled]);
 
 		const detail = mount(JobDetail, { props: { job: scheduled } });
-		expect(detail.get('button.button-secondary').text()).toContain('Run now');
+		expect(detail.findAll('button.button-secondary').some(button => button.text().includes('Run now'))).toBe(true);
+		const cancelDetail = detail.findAll('button.button-secondary').find(button => button.text().includes('Cancel job'));
+		expect(cancelDetail).toBeDefined();
+		await cancelDetail?.trigger('click');
+		expect(detail.emitted('cancel')?.[0]).toEqual([scheduled]);
 	});
 
 	it('shows skipped branches', () => {

--- a/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
+++ b/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
@@ -1385,6 +1385,53 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 	}
 
 	/// <inheritdoc />
+	public ValueTask CancelAsync(string jobId, CancellationToken cancellationToken = default)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
+		return ExecuteWithStrategyAsync(
+			operationCancellationToken => CancelCoreAsync(jobId, operationCancellationToken),
+			cancellationToken
+		);
+	}
+
+	private async Task CancelCoreAsync(string jobId, CancellationToken cancellationToken)
+	{
+		var now = _timeProvider.GetUtcNow();
+		await using var context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+		await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+		var job = await context.Set<ImmediateJobEntity>()
+			.SingleOrDefaultAsync(item => item.Id == jobId, cancellationToken)
+			.ConfigureAwait(false)
+			?? throw new KeyNotFoundException($"Job '{jobId}' was not found.");
+		if (IsTerminal(job.State))
+			throw new ImmediateJobException("Only a non-terminal job can be cancelled.");
+
+		if (job.State == JobState.Active)
+		{
+			var execution = await GetOrMaterializeExecutionAsync(context, job, cancellationToken).ConfigureAwait(false)
+				?? throw new ImmediateJobException($"Active job '{job.Id}' has no execution ordinal.");
+			execution.State = JobExecutionState.Cancelled;
+			execution.CompletedAt = now;
+			execution.Error = null;
+		}
+
+		job.State = JobState.Cancelled;
+		job.CompletedAt = now;
+		job.WorkerId = null;
+		job.LeaseExpiresAt = null;
+		job.ConcurrencyStamp = Guid.NewGuid();
+		await PropagateTerminalAsync(context, job, now, cancellationToken).ConfigureAwait(false);
+
+		var terminalGroups = GetTerminalFairQueueGroups(context);
+		_ = await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+		await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+		foreach (var (queueName, groupId) in terminalGroups)
+		{
+			await TryRemoveFairQueueCursorAsync(queueName, groupId, CancellationToken.None).ConfigureAwait(false);
+		}
+	}
+
+	/// <inheritdoc />
 	public ValueTask RetryAsync(string jobId, CancellationToken cancellationToken = default)
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(jobId);

--- a/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
+++ b/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
@@ -1388,7 +1388,7 @@ public sealed class EntityFrameworkCoreJobStorage<TContext>(
 	public ValueTask CancelAsync(string jobId, CancellationToken cancellationToken = default)
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
-		return ExecuteWithStrategyAsync(
+		return RetryConcurrencyAsync(
 			operationCancellationToken => CancelCoreAsync(jobId, operationCancellationToken),
 			cancellationToken
 		);

--- a/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
+++ b/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
@@ -1444,6 +1444,56 @@ public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage,
 	}
 
 	/// <inheritdoc />
+	public async ValueTask CancelAsync(string jobId, CancellationToken cancellationToken = default)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
+		var terminalGroups = new HashSet<(string QueueName, string GroupId)>();
+		await RetryConcurrencyAsync(
+			connection => CancelCoreAsync(connection, jobId, terminalGroups, cancellationToken),
+			cancellationToken
+		).ConfigureAwait(false);
+		await CleanupFairQueueGroupsAsync(terminalGroups).ConfigureAwait(false);
+	}
+
+	private async Task CancelCoreAsync(
+		DataConnection connection,
+		string jobId,
+		ISet<(string QueueName, string GroupId)> terminalGroups,
+		CancellationToken cancellationToken
+	)
+	{
+		var job = await Jobs(connection).SingleOrDefaultAsync(item => item.Id == jobId, cancellationToken)
+			.ConfigureAwait(false)
+			?? throw new KeyNotFoundException($"Job '{jobId}' was not found.");
+		if (IsTerminal(job.State))
+			throw new ImmediateJobException("Only a non-terminal job can be cancelled.");
+
+		var now = _timeProvider.GetUtcNow().UtcTicks;
+		if (job.State == JobState.Active)
+		{
+			_ = await GetOrMaterializeExecutionAsync(connection, job, cancellationToken).ConfigureAwait(false)
+				?? throw new ImmediateJobException($"Active job '{job.Id}' has no execution ordinal.");
+			_ = await Executions(connection)
+				.Where(execution => execution.JobId == job.Id && execution.Attempt == job.Attempt)
+				.Set(execution => execution.State, JobExecutionState.Cancelled)
+				.Set(execution => execution.CompletedAt, now)
+				.Set(execution => execution.Error, (string?)null)
+				.UpdateAsync(cancellationToken)
+				.ConfigureAwait(false);
+		}
+
+		var oldStamp = job.ConcurrencyStamp;
+		job.State = JobState.Cancelled;
+		job.CompletedAt = now;
+		job.WorkerId = null;
+		job.LeaseExpiresAt = null;
+		job.ConcurrencyStamp = Guid.NewGuid();
+		if (!await UpdateJobAsync(connection, job, oldStamp, cancellationToken).ConfigureAwait(false))
+			throw new LostRaceException();
+		await PropagateTerminalAsync(connection, job, now, terminalGroups, cancellationToken).ConfigureAwait(false);
+	}
+
+	/// <inheritdoc />
 	public ValueTask RetryAsync(string jobId, CancellationToken cancellationToken = default)
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(jobId);

--- a/src/Immediate.Jobs.Redis/RedisJobStorage.cs
+++ b/src/Immediate.Jobs.Redis/RedisJobStorage.cs
@@ -445,6 +445,23 @@ public sealed class RedisJobStorage : IRecurringJobStorage, IDisposable
 	}
 
 	/// <inheritdoc />
+	public async ValueTask CancelAsync(string jobId, CancellationToken cancellationToken = default)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
+		var now = _timeProvider.GetUtcNow();
+		var result = await EvaluateInt64Async(
+			RedisScripts.Cancel,
+			[JobKey(jobId), LeasesKey, ExecutionIndexKey(jobId), ExecutionDataKey(jobId)],
+			[jobId, Ticks(now), Score(now), _root],
+			cancellationToken
+		).ConfigureAwait(false);
+		if (result == 0)
+			throw new KeyNotFoundException($"Job '{jobId}' was not found.");
+		if (result < 0)
+			throw new ImmediateJobException("Only a non-terminal job can be cancelled.");
+	}
+
+	/// <inheritdoc />
 	public async ValueTask RetryAsync(string jobId, CancellationToken cancellationToken = default)
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(jobId);

--- a/src/Immediate.Jobs.Redis/RedisScripts.cs
+++ b/src/Immediate.Jobs.Redis/RedisScripts.cs
@@ -247,6 +247,36 @@ internal static class RedisScripts
 		return 1
 		""";
 
+	internal const string Cancel =
+		"""
+		if redis.call('EXISTS', KEYS[1]) == 0 then return 0 end
+		local values = redis.call('HMGET', KEYS[1], 'state', 'queue', 'dueMember', 'attempt',
+			'worker', 'executionStartedAt', 'executionTraceId', 'executionSpanId')
+		local state = values[1]
+		if state == '5' or state == '6' or state == '7' or state == '8' then return -1 end
+		local attempt = tonumber(values[4] or '0')
+		if state == '4' and attempt > 0 then
+			local field = tostring(attempt) .. ':'
+			if redis.call('HEXISTS', KEYS[4], field .. 'state') == 0 then
+				redis.call('ZADD', KEYS[3], attempt, attempt)
+				redis.call('HSET', KEYS[4],
+					field .. 'worker', values[5] or '', field .. 'acquired', '',
+					field .. 'started', values[6] or '', field .. 'trace', values[7] or '',
+					field .. 'span', values[8] or '', field .. 'synthetic', '1')
+			end
+			redis.call('HSET', KEYS[4],
+				field .. 'state', '3', field .. 'completed', ARGV[2], field .. 'error', '')
+		end
+		redis.call('HSET', KEYS[1],
+			'state', '7', 'worker', '', 'lease', '', 'error', '', 'completed', ARGV[2])
+		redis.call('SREM', ARGV[4] .. 'state:' .. state, ARGV[1])
+		redis.call('SADD', ARGV[4] .. 'state:7', ARGV[1])
+		redis.call('ZREM', KEYS[2], ARGV[1])
+		if values[3] then redis.call('ZREM', ARGV[4] .. 'due:' .. values[2], values[3]) end
+		redis.call('ZADD', ARGV[4] .. 'completed:7', ARGV[3], ARGV[1])
+		return 1
+		""";
+
 	internal const string Retry =
 		"""
 		if redis.call('EXISTS', KEYS[1]) == 0 then return 0 end

--- a/src/Immediate.Jobs.Shared/IJobStorage.cs
+++ b/src/Immediate.Jobs.Shared/IJobStorage.cs
@@ -116,6 +116,12 @@ public interface IJobStorage : IAsyncDisposable
 	/// <returns>The job status, or <see langword="null"/> when the invocation does not exist.</returns>
 	ValueTask<JobStatus?> GetJobStatusAsync(string jobId, CancellationToken cancellationToken = default);
 
+	/// <summary>Moves a non-terminal invocation to the cancelled state.</summary>
+	/// <param name="jobId">The non-terminal invocation identifier.</param>
+	/// <param name="cancellationToken">A token that can cancel the storage operation.</param>
+	/// <returns>A value task that represents the asynchronous cancellation.</returns>
+	ValueTask CancelAsync(string jobId, CancellationToken cancellationToken = default);
+
 	/// <summary>Moves a failed invocation back to pending or fast-forwards a scheduled invocation.</summary>
 	/// <param name="jobId">The failed or scheduled invocation identifier.</param>
 	/// <param name="cancellationToken">A token that can cancel the storage operation.</param>

--- a/src/Immediate.Jobs.Shared/InMemoryJobStorage.cs
+++ b/src/Immediate.Jobs.Shared/InMemoryJobStorage.cs
@@ -1053,6 +1053,27 @@ public sealed class InMemoryJobStorage(TimeProvider timeProvider) :
 	}
 
 	/// <inheritdoc />
+	public ValueTask CancelAsync(string jobId, CancellationToken cancellationToken = default)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
+		cancellationToken.ThrowIfCancellationRequested();
+		lock (_gate)
+		{
+			if (!_jobs.TryGetValue(jobId, out var job))
+				throw new KeyNotFoundException($"Job '{jobId}' was not found.");
+			if (IsTerminal(job.State))
+				throw new ImmediateJobException("Only a non-terminal job can be cancelled.");
+
+			var now = timeProvider.GetUtcNow();
+			if (job.State == JobState.Active)
+				CompleteExecution(job, JobExecutionState.Cancelled, now);
+			TransitionToTerminal(jobId, JobState.Cancelled, error: null, now);
+		}
+
+		return ValueTask.CompletedTask;
+	}
+
+	/// <inheritdoc />
 	public ValueTask RetryAsync(string jobId, CancellationToken cancellationToken = default)
 	{
 		cancellationToken.ThrowIfCancellationRequested();

--- a/src/Immediate.Jobs.Shared/JobBatches.cs
+++ b/src/Immediate.Jobs.Shared/JobBatches.cs
@@ -3,6 +3,13 @@ namespace Immediate.Jobs.Shared;
 /// <summary>Creates atomic batches of typed generated jobs.</summary>
 public interface IJobBatchScheduler
 {
+	/// <summary>Cancels every non-terminal member of a committed batch.</summary>
+	/// <param name="handle">The committed batch to cancel.</param>
+	/// <param name="cancellationToken">A token that can cancel the storage operation.</param>
+	/// <returns>A value task that represents the asynchronous cancellation.</returns>
+	ValueTask CancelAsync(BatchHandle handle, CancellationToken cancellationToken = default) =>
+		throw new NotSupportedException("This scheduler does not support cancelling batches.");
+
 	/// <summary>Begins an in-memory batch buffer.</summary>
 	/// <returns>The new batch buffer.</returns>
 	JobBatch Begin();
@@ -33,6 +40,13 @@ public sealed class JobBatchScheduler(
 	IIdGenerator idGenerator
 ) : IJobBatchScheduler
 {
+	/// <inheritdoc />
+	public ValueTask CancelAsync(BatchHandle handle, CancellationToken cancellationToken = default)
+	{
+		ArgumentNullException.ThrowIfNull(handle);
+		return JobStorageCapabilityGuards.RequireGraph(storage).CancelBatchAsync(handle.Id, cancellationToken);
+	}
+
 	/// <inheritdoc />
 	public JobBatch Begin() =>
 		new(

--- a/src/Immediate.Jobs.Shared/JobSchedulers.cs
+++ b/src/Immediate.Jobs.Shared/JobSchedulers.cs
@@ -7,6 +7,13 @@ namespace Immediate.Jobs.Shared;
 /// <typeparam name="TPayload">The job payload type.</typeparam>
 public interface IJobScheduler<TPayload>
 {
+	/// <summary>Cancels a non-terminal durable invocation.</summary>
+	/// <param name="handle">The invocation to cancel.</param>
+	/// <param name="cancellationToken">A token that can cancel the storage operation.</param>
+	/// <returns>A value task that represents the asynchronous cancellation.</returns>
+	ValueTask CancelAsync(JobHandle handle, CancellationToken cancellationToken = default) =>
+		throw new NotSupportedException("This scheduler does not support cancelling jobs.");
+
 	/// <summary>Enqueues work immediately and returns its opaque invocation identifier.</summary>
 	/// <param name="payload">The payload to enqueue.</param>
 	/// <param name="cancellationToken">A token that can cancel the enqueue operation.</param>
@@ -143,6 +150,13 @@ public abstract class JobScheduler<TPayload>(
 	/// <summary>The stable queue used for new invocations.</summary>
 	/// <value>The queue name.</value>
 	protected string QueueName { get; } = queueName;
+
+	/// <inheritdoc />
+	public ValueTask CancelAsync(JobHandle handle, CancellationToken cancellationToken = default)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(handle.Id, nameof(handle));
+		return Storage.CancelAsync(handle.Id, cancellationToken);
+	}
 
 	/// <inheritdoc />
 	public ValueTask<JobHandle> EnqueueAsync(TPayload payload, CancellationToken cancellationToken = default) =>

--- a/src/Immediate.Jobs.Shared/SingleServerJobStorage.cs
+++ b/src/Immediate.Jobs.Shared/SingleServerJobStorage.cs
@@ -401,6 +401,14 @@ public sealed class SingleServerJobStorage :
 	}
 
 	/// <inheritdoc />
+	public async ValueTask CancelAsync(string jobId, CancellationToken cancellationToken = default)
+	{
+		await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+		await DurableStorage.CancelAsync(jobId, cancellationToken).ConfigureAwait(false);
+		await _primary.CancelAsync(jobId, cancellationToken).ConfigureAwait(false);
+	}
+
+	/// <inheritdoc />
 	public async ValueTask RetryAsync(string jobId, CancellationToken cancellationToken = default)
 	{
 		await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Immediate.Jobs.Testing/CaptureOnlyJobScheduler.cs
+++ b/src/Immediate.Jobs.Testing/CaptureOnlyJobScheduler.cs
@@ -8,6 +8,7 @@ namespace Immediate.Jobs.Testing;
 public class CaptureOnlyJobScheduler<TPayload>(TimeProvider? timeProvider = null) : IJobScheduler<TPayload>
 {
 	private readonly List<ScheduledJobCapture<TPayload>> _captures = [];
+	private readonly HashSet<string> _cancelledIds = new(StringComparer.Ordinal);
 	private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
 
 	/// <summary>All calls captured in call order.</summary>
@@ -17,6 +18,22 @@ public class CaptureOnlyJobScheduler<TPayload>(TimeProvider? timeProvider = null
 	/// <summary>The latest captured call, or <see langword="null"/> when none exists.</summary>
 	/// <value>The latest captured call, or <see langword="null"/>.</value>
 	public ScheduledJobCapture<TPayload>? Last => _captures.Count == 0 ? null : _captures[^1];
+
+	/// <summary>The identifiers explicitly cancelled through this scheduler.</summary>
+	/// <value>The cancelled invocation identifiers.</value>
+	public IReadOnlySet<string> CancelledIds => _cancelledIds;
+
+	/// <inheritdoc />
+	public virtual ValueTask CancelAsync(JobHandle handle, CancellationToken cancellationToken = default)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(handle.Id, nameof(handle));
+		cancellationToken.ThrowIfCancellationRequested();
+		if (!_captures.Any(capture => string.Equals(capture.Id, handle.Id, StringComparison.Ordinal)))
+			throw new KeyNotFoundException($"Job '{handle.Id}' was not found.");
+		if (!_cancelledIds.Add(handle.Id))
+			throw new ImmediateJobException("Only a non-terminal job can be cancelled.");
+		return ValueTask.CompletedTask;
+	}
 
 	/// <inheritdoc />
 	public virtual ValueTask<JobHandle> EnqueueAsync(TPayload payload, CancellationToken cancellationToken = default) =>
@@ -69,8 +86,12 @@ public class CaptureOnlyJobScheduler<TPayload>(TimeProvider? timeProvider = null
 		CancellationToken cancellationToken
 	) => CaptureAsync(payload, runAt, groupId, cancellationToken);
 
-	/// <summary>Clears every captured call.</summary>
-	public void Clear() => _captures.Clear();
+	/// <summary>Clears every captured call and cancellation.</summary>
+	public void Clear()
+	{
+		_captures.Clear();
+		_cancelledIds.Clear();
+	}
 
 	/// <summary>Creates invocation identifiers. Override when a test requires predictable identifiers.</summary>
 	/// <returns>A new invocation identifier.</returns>

--- a/tests/Immediate.Jobs.FunctionalTests/BatchesAndContinuationsTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/BatchesAndContinuationsTests.cs
@@ -30,6 +30,32 @@ public sealed class BatchesAndContinuationsTests
 	}
 
 	[Fact]
+	public async Task TypedSchedulersCancelJobsAndCommittedBatches()
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var harness = CreateHarness();
+		await using var scope = harness.Services.CreateAsyncScope();
+		var batches = scope.ServiceProvider.GetRequiredService<IJobBatchScheduler>();
+		var scheduler = scope.ServiceProvider.GetRequiredService<BatchWorkflowJob.Scheduler>();
+		var jobHandle = await scheduler.EnqueueAsync(new("cancel-job"), cancellationToken);
+
+		await scheduler.CancelAsync(jobHandle, cancellationToken);
+
+		Assert.Equal(JobState.Cancelled, (await harness.GetJobAsync(jobHandle.Id, cancellationToken)).State);
+
+		await using var batch = batches.Begin();
+		var memberHandle = scheduler.AddToBatch(batch, new("cancel-batch"));
+		var batchHandle = await batch.CommitAsync(cancellationToken);
+
+		await batches.CancelAsync(batchHandle, cancellationToken);
+
+		Assert.Equal(JobState.Cancelled, (await harness.GetJobAsync(memberHandle.Id, cancellationToken)).State);
+		var graphStorage = Assert.IsAssignableFrom<IJobGraphStorage>(harness.Storage);
+		var status = Assert.IsType<BatchStatus>(await graphStorage.GetBatchStatusAsync(batchHandle.Id, cancellationToken));
+		Assert.Equal(BatchState.Cancelled, status.State);
+	}
+
+	[Fact]
 	public async Task BatchBuffersUntilCommitAndDisposalRollsBackUncommittedJobs()
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;

--- a/tests/Immediate.Jobs.FunctionalTests/Packages/DashboardPackageTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/Packages/DashboardPackageTests.cs
@@ -331,7 +331,7 @@ public sealed class DashboardPackageTests
 	[InlineData("POST", "/jobs/api/batches/missing/cancel")]
 	[InlineData("DELETE", "/jobs/api/batches/missing")]
 	[InlineData("POST", "/jobs/api/jobs/missing/retry")]
-	[InlineData("POST", "/jobs/api/jobs/missing")]
+	[InlineData("POST", "/jobs/api/jobs/missing/cancel")]
 	public async Task InMemoryDashboardReturnsNotFoundForMissingMutationTargets(string method, string path)
 	{
 		var builder = WebApplication.CreateBuilder(new WebApplicationOptions
@@ -380,7 +380,7 @@ public sealed class DashboardPackageTests
 		await app.StartAsync(cancellationToken);
 
 		using var response = await app.GetTestClient().PostAsync(
-			new Uri("/jobs/api/jobs/dashboard-cancel", UriKind.Relative),
+			new Uri("/jobs/api/jobs/dashboard-cancel/cancel", UriKind.Relative),
 			content: null,
 			cancellationToken
 		);
@@ -388,7 +388,7 @@ public sealed class DashboardPackageTests
 		Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
 		Assert.Equal(JobState.Cancelled, (await storage.GetJobStatusAsync("dashboard-cancel", cancellationToken))!.State);
 		using var conflict = await app.GetTestClient().PostAsync(
-			new Uri("/jobs/api/jobs/dashboard-cancel", UriKind.Relative),
+			new Uri("/jobs/api/jobs/dashboard-cancel/cancel", UriKind.Relative),
 			content: null,
 			cancellationToken
 		);

--- a/tests/Immediate.Jobs.FunctionalTests/Packages/DashboardPackageTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/Packages/DashboardPackageTests.cs
@@ -330,6 +330,7 @@ public sealed class DashboardPackageTests
 	[InlineData("POST", "/jobs/api/recurring/missing/resume")]
 	[InlineData("POST", "/jobs/api/batches/missing/cancel")]
 	[InlineData("DELETE", "/jobs/api/batches/missing")]
+	[InlineData("POST", "/jobs/api/jobs/missing/cancel")]
 	[InlineData("POST", "/jobs/api/jobs/missing/retry")]
 	[InlineData("DELETE", "/jobs/api/jobs/missing")]
 	public async Task InMemoryDashboardReturnsNotFoundForMissingMutationTargets(string method, string path)
@@ -350,6 +351,49 @@ public sealed class DashboardPackageTests
 		using var response = await app.GetTestClient().SendAsync(request, TestContext.Current.CancellationToken);
 
 		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task DashboardCancelsNonTerminalJob()
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var storage = new InMemoryJobStorage(TimeProvider.System);
+		var now = TimeProvider.System.GetUtcNow();
+		await storage.EnqueueAsync(new()
+		{
+			Id = "dashboard-cancel",
+			JobName = "cancel-test",
+			Payload = "{}",
+			State = JobState.Pending,
+			DueAt = now,
+			CreatedAt = now,
+		}, cancellationToken);
+		var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+		{
+			EnvironmentName = Environments.Development,
+		});
+		_ = builder.WebHost.UseTestServer();
+		_ = builder.Services.AddImmediateJobsDashboard();
+		_ = builder.Services.AddSingleton<IJobStorage>(storage);
+
+		await using var app = builder.Build();
+		_ = app.MapImmediateJobsDashboard();
+		await app.StartAsync(cancellationToken);
+
+		using var response = await app.GetTestClient().PostAsync(
+			new Uri("/jobs/api/jobs/dashboard-cancel/cancel", UriKind.Relative),
+			content: null,
+			cancellationToken
+		);
+
+		Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+		Assert.Equal(JobState.Cancelled, (await storage.GetJobStatusAsync("dashboard-cancel", cancellationToken))!.State);
+		using var conflict = await app.GetTestClient().PostAsync(
+			new Uri("/jobs/api/jobs/dashboard-cancel/cancel", UriKind.Relative),
+			content: null,
+			cancellationToken
+		);
+		Assert.Equal(HttpStatusCode.Conflict, conflict.StatusCode);
 	}
 
 	[Theory]

--- a/tests/Immediate.Jobs.FunctionalTests/Packages/DashboardPackageTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/Packages/DashboardPackageTests.cs
@@ -330,9 +330,8 @@ public sealed class DashboardPackageTests
 	[InlineData("POST", "/jobs/api/recurring/missing/resume")]
 	[InlineData("POST", "/jobs/api/batches/missing/cancel")]
 	[InlineData("DELETE", "/jobs/api/batches/missing")]
-	[InlineData("POST", "/jobs/api/jobs/missing/cancel")]
 	[InlineData("POST", "/jobs/api/jobs/missing/retry")]
-	[InlineData("DELETE", "/jobs/api/jobs/missing")]
+	[InlineData("POST", "/jobs/api/jobs/missing")]
 	public async Task InMemoryDashboardReturnsNotFoundForMissingMutationTargets(string method, string path)
 	{
 		var builder = WebApplication.CreateBuilder(new WebApplicationOptions
@@ -381,7 +380,7 @@ public sealed class DashboardPackageTests
 		await app.StartAsync(cancellationToken);
 
 		using var response = await app.GetTestClient().PostAsync(
-			new Uri("/jobs/api/jobs/dashboard-cancel/cancel", UriKind.Relative),
+			new Uri("/jobs/api/jobs/dashboard-cancel", UriKind.Relative),
 			content: null,
 			cancellationToken
 		);
@@ -389,7 +388,7 @@ public sealed class DashboardPackageTests
 		Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
 		Assert.Equal(JobState.Cancelled, (await storage.GetJobStatusAsync("dashboard-cancel", cancellationToken))!.State);
 		using var conflict = await app.GetTestClient().PostAsync(
-			new Uri("/jobs/api/jobs/dashboard-cancel/cancel", UriKind.Relative),
+			new Uri("/jobs/api/jobs/dashboard-cancel", UriKind.Relative),
 			content: null,
 			cancellationToken
 		);

--- a/tests/Immediate.Jobs.FunctionalTests/Packages/TestingPackageTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/Packages/TestingPackageTests.cs
@@ -24,6 +24,10 @@ public sealed class TestingPackageTests
 		Assert.Equal(id.Id, capture.Id);
 		Assert.Equal(payload, capture.Payload);
 		Assert.Equal("tenant-a", capture.GroupId);
+
+		await scheduler.CancelAsync(id, TestContext.Current.CancellationToken);
+
+		Assert.Contains(id.Id, scheduler.CancelledIds);
 	}
 
 	[Fact]

--- a/tests/Immediate.Jobs.FunctionalTests/Storage/EntityFrameworkCoreJobStorageTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/Storage/EntityFrameworkCoreJobStorageTests.cs
@@ -99,6 +99,25 @@ public sealed class EntityFrameworkCoreJobStorageTests
 	}
 
 	[Fact]
+	public async Task CancellationRetriesAfterConcurrencyConflict()
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		var interceptor = new CancelConcurrencyInterceptor();
+		await using var fixture = await StorageFixture.CreateAsync(
+			cancellationToken,
+			interceptor: interceptor
+		);
+		var storage = fixture.CreateStorage();
+		var job = CreateJob(fixture.TimeProvider.GetUtcNow(), 1) with { Id = "cancel-contention" };
+		await storage.EnqueueAsync(job, cancellationToken);
+
+		await storage.CancelAsync(job.Id, cancellationToken);
+
+		Assert.Equal(1, interceptor.Conflicts);
+		Assert.Equal(JobState.Cancelled, (await storage.GetJobStatusAsync(job.Id, cancellationToken))!.State);
+	}
+
+	[Fact]
 	public async Task FairQueuesRotateGroupsAcrossCapacityOneAcquisitions()
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;
@@ -1147,7 +1166,7 @@ public sealed class EntityFrameworkCoreJobStorageTests
 		public static async Task<StorageFixture> CreateAsync(
 			CancellationToken cancellationToken,
 			bool useRetryingExecutionStrategy = false,
-			DbCommandInterceptor? interceptor = null
+			IInterceptor? interceptor = null
 		)
 		{
 			var connectionString = $"Data Source=jobs-{Guid.NewGuid():N};Mode=Memory;Cache=Shared";
@@ -1188,6 +1207,33 @@ public sealed class EntityFrameworkCoreJobStorageTests
 		{
 			await services.DisposeAsync();
 			await _anchor.DisposeAsync();
+		}
+	}
+
+	private sealed class CancelConcurrencyInterceptor : SaveChangesInterceptor
+	{
+		private int _conflicts;
+
+		public int Conflicts => Volatile.Read(ref _conflicts);
+
+		public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+			DbContextEventData eventData,
+			InterceptionResult<int> result,
+			CancellationToken cancellationToken = default
+		)
+		{
+			var cancelling = eventData.Context?.ChangeTracker
+				.Entries()
+				.Any(static entry =>
+					entry.State == EntityState.Modified
+					&& entry.Properties.Any(static property =>
+						property.IsModified
+						&& string.Equals(property.Metadata.Name, "State", StringComparison.Ordinal)
+						&& Equals(property.CurrentValue, JobState.Cancelled))) == true;
+			if (cancelling && Interlocked.CompareExchange(ref _conflicts, 1, 0) == 0)
+				throw new DbUpdateConcurrencyException("Injected cancellation concurrency conflict.");
+
+			return base.SavingChangesAsync(eventData, result, cancellationToken);
 		}
 	}
 

--- a/tests/Immediate.Jobs.FunctionalTests/Storage/QueueStorageTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/Storage/QueueStorageTests.cs
@@ -83,6 +83,51 @@ public sealed class QueueStorageTests
 	}
 
 	[Fact]
+	public async Task CancellingAnActiveJobClosesItsExecutionAndFencesTheWorker()
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		var clock = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+		await using var storage = new InMemoryJobStorage(clock);
+		var job = new JobRecord
+		{
+			Id = "cancel-active",
+			JobName = "cancel-test",
+			Payload = "{}",
+			State = JobState.Pending,
+			DueAt = clock.GetUtcNow(),
+			CreatedAt = clock.GetUtcNow(),
+		};
+		await storage.EnqueueAsync(job, cancellationToken);
+		var active = Assert.Single(await storage.AcquireDueJobsAsync(new()
+		{
+			WorkerId = "worker",
+			Lease = TimeSpan.FromMinutes(1),
+			BatchSize = 1,
+			Queues =
+			[
+				new()
+				{
+					QueueName = JobQueueDefinition.DefaultName,
+					Capacity = 1,
+					JobCapacities = new Dictionary<string, int> { [job.JobName] = 1 },
+				},
+			],
+		}, cancellationToken));
+
+		await storage.CancelAsync(job.Id, cancellationToken);
+
+		Assert.Equal(JobState.Cancelled, (await storage.GetJobStatusAsync(job.Id, cancellationToken))!.State);
+		var execution = Assert.Single(await storage.QueryJobExecutionsAsync(new() { JobId = job.Id }, cancellationToken));
+		Assert.Equal(JobExecutionState.Cancelled, execution.State);
+		_ = await Assert.ThrowsAsync<ImmediateJobException>(
+			() => storage.CompleteAsync(job.Id, active.Attempt, "worker", cancellationToken).AsTask()
+		);
+		_ = await Assert.ThrowsAsync<ImmediateJobException>(
+			() => storage.CancelAsync(job.Id, cancellationToken).AsTask()
+		);
+	}
+
+	[Fact]
 	public async Task AcquisitionHonorsQueueOrderAndQueueAndJobCapacities()
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;

--- a/tests/Immediate.Jobs.FunctionalTests/StorageCapabilityTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/StorageCapabilityTests.cs
@@ -249,6 +249,9 @@ public sealed class StorageCapabilityTests
 			CancellationToken cancellationToken = default
 		) => _inner.GetJobStatusAsync(jobId, cancellationToken);
 
+		public ValueTask CancelAsync(string jobId, CancellationToken cancellationToken = default) =>
+			_inner.CancelAsync(jobId, cancellationToken);
+
 		public ValueTask RetryAsync(string jobId, CancellationToken cancellationToken = default) =>
 			_inner.RetryAsync(jobId, cancellationToken);
 

--- a/tests/Immediate.Jobs.StorageTests/RedisStorageTests.cs
+++ b/tests/Immediate.Jobs.StorageTests/RedisStorageTests.cs
@@ -271,12 +271,44 @@ public sealed class RedisStorageTests(RedisStorageFixture fixture)
 	}
 
 	[Fact]
+	public async Task CancelActiveJobClosesExecutionAndFencesWorker()
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var connection = await ConnectionMultiplexer.ConnectAsync(fixture.Container.GetConnectionString());
+		var timeProvider = CreateTimeProvider();
+		await using var storage = new RedisJobStorage(connection, CreateOptions(), timeProvider);
+		var job = CreateJob("cancel-active", timeProvider.GetUtcNow());
+		await storage.EnqueueAsync(job, cancellationToken);
+		var active = Assert.Single(await storage.AcquireDueJobsAsync(CreateRequest("worker", 1), cancellationToken));
+
+		await storage.CancelAsync(job.Id, cancellationToken);
+
+		Assert.Equal(JobState.Cancelled, (await storage.GetJobStatusAsync(job.Id, cancellationToken))!.State);
+		var execution = Assert.Single(await storage.QueryJobExecutionsAsync(new() { JobId = job.Id }, cancellationToken));
+		Assert.Equal(JobExecutionState.Cancelled, execution.State);
+		_ = await Assert.ThrowsAsync<ImmediateJobException>(
+			() => storage.CompleteAsync(job.Id, active.Attempt, "worker", cancellationToken).AsTask()
+		);
+		_ = await Assert.ThrowsAsync<ImmediateJobException>(
+			() => storage.CancelAsync(job.Id, cancellationToken).AsTask()
+		);
+
+		var pending = CreateJob("cancel-pending", timeProvider.GetUtcNow());
+		await storage.EnqueueAsync(pending, cancellationToken);
+		await storage.CancelAsync(pending.Id, cancellationToken);
+		Assert.Empty(await storage.AcquireDueJobsAsync(CreateRequest("worker", 1), cancellationToken));
+	}
+
+	[Fact]
 	public async Task MissingDashboardActionsThrowKeyNotFoundException()
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;
 		await using var connection = await ConnectionMultiplexer.ConnectAsync(fixture.Container.GetConnectionString());
 		await using var storage = new RedisJobStorage(connection, CreateOptions(), CreateTimeProvider());
 
+		_ = await Assert.ThrowsAsync<KeyNotFoundException>(
+			() => storage.CancelAsync("missing", cancellationToken).AsTask()
+		);
 		_ = await Assert.ThrowsAsync<KeyNotFoundException>(
 			() => storage.RetryAsync("missing", cancellationToken).AsTask()
 		);

--- a/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
+++ b/tests/Immediate.Jobs.StorageTests/RelationalStorageMatrixTests.cs
@@ -1041,6 +1041,86 @@ public sealed class RelationalStorageMatrixTests(StorageContainers containers)
 
 	[Theory]
 	[MemberData(nameof(Matrix))]
+	public async Task CancelActiveJobClosesExecutionAndFencesWorker(DatabaseKind database, AdapterKind adapter)
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var fixture = await CreateFixtureAsync(database, adapter, cancellationToken);
+		var storage = fixture.Storage;
+		var job = CreateJob("cancel-active", fixture.TimeProvider.GetUtcNow());
+		await storage.EnqueueAsync(job, cancellationToken);
+		var active = Assert.Single(await storage.AcquireDueJobsAsync(CreateRequest("worker", 1), cancellationToken));
+
+		await storage.CancelAsync(job.Id, cancellationToken);
+
+		Assert.Equal(JobState.Cancelled, (await storage.GetJobStatusAsync(job.Id, cancellationToken))!.State);
+		var execution = Assert.Single(await storage.QueryJobExecutionsAsync(new() { JobId = job.Id }, cancellationToken));
+		Assert.Equal(JobExecutionState.Cancelled, execution.State);
+		_ = await Assert.ThrowsAsync<ImmediateJobException>(
+			() => storage.CompleteAsync(job.Id, active.Attempt, "worker", cancellationToken).AsTask()
+		);
+		_ = await Assert.ThrowsAsync<ImmediateJobException>(
+			() => storage.CancelAsync(job.Id, cancellationToken).AsTask()
+		);
+	}
+
+	[Theory]
+	[MemberData(nameof(Matrix))]
+	public async Task CancelBatchMemberPropagatesContinuations(DatabaseKind database, AdapterKind adapter)
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		await using var fixture = await CreateFixtureAsync(database, adapter, cancellationToken);
+		var storage = fixture.GraphStorage;
+		var now = fixture.TimeProvider.GetUtcNow();
+		var parent = CreateJob("cancel-parent", now) with { BatchId = "cancel-member-batch" };
+		var successChild = CreateJob("cancel-success-child", now) with
+		{
+			BatchId = "cancel-member-batch",
+			State = JobState.AwaitingContinuation,
+			RemainingDependencies = 1,
+		};
+		var completeChild = CreateJob("cancel-complete-child", now) with
+		{
+			BatchId = "cancel-member-batch",
+			State = JobState.AwaitingContinuation,
+			RemainingDependencies = 1,
+		};
+		await storage.EnqueueBatchAsync(new()
+		{
+			Id = "cancel-member-batch",
+			CreatedAt = now,
+			TotalJobs = 3,
+			PendingCount = 3,
+			State = BatchState.Executing,
+		}, [parent, successChild, completeChild],
+		[
+			new()
+			{
+				ChildJobId = successChild.Id,
+				ParentJobId = parent.Id,
+				Trigger = ContinuationTrigger.Success,
+			},
+			new()
+			{
+				ChildJobId = completeChild.Id,
+				ParentJobId = parent.Id,
+				Trigger = ContinuationTrigger.Complete,
+			},
+		], cancellationToken);
+
+		await storage.CancelAsync(parent.Id, cancellationToken);
+
+		Assert.Equal(JobState.Cancelled, (await storage.GetJobStatusAsync(parent.Id, cancellationToken))!.State);
+		Assert.Equal(JobState.Skipped, (await storage.GetJobStatusAsync(successChild.Id, cancellationToken))!.State);
+		Assert.Equal(JobState.Pending, (await storage.GetJobStatusAsync(completeChild.Id, cancellationToken))!.State);
+		var status = Assert.IsType<BatchStatus>(await storage.GetBatchStatusAsync("cancel-member-batch", cancellationToken));
+		Assert.Equal(BatchState.Executing, status.State);
+		Assert.Equal(1, status.Cancelled);
+		Assert.Equal(1, status.Skipped);
+		Assert.Equal(1, status.Remaining);
+	}
+
+	[Theory]
+	[MemberData(nameof(Matrix))]
 	public async Task SkippedFailureBranchDoesNotCancelSuccessfulBatch(
 		DatabaseKind database,
 		AdapterKind adapter
@@ -1114,6 +1194,9 @@ public sealed class RelationalStorageMatrixTests(StorageContainers containers)
 		var graphStorage = Assert.IsType<IJobGraphStorage>(storage, exactMatch: false);
 		var recurringStorage = Assert.IsType<IRecurringJobStorage>(storage, exactMatch: false);
 
+		_ = await Assert.ThrowsAsync<KeyNotFoundException>(
+			() => storage.CancelAsync("missing", cancellationToken).AsTask()
+		);
 		_ = await Assert.ThrowsAsync<KeyNotFoundException>(
 			() => storage.RetryAsync("missing", cancellationToken).AsTask()
 		);


### PR DESCRIPTION
## Summary

- add CancelAsync(JobHandle) to generated job schedulers and CancelAsync(BatchHandle) to IJobBatchScheduler
- implement durable single-job cancellation for in-memory, single-server, EF Core, LINQ to DB, and Redis storage
- expose POST /api/jobs/{id}/cancel through the Immediate.Apis/Immediate.Validations dashboard API
- add confirmation-backed cancel actions to job tables, job details, and batch workflow details
- document cancellation semantics and cover active-execution fencing, continuations, missing/conflicting resources, and client behavior

## Stack

This PR is stacked directly on #84. Merge #84 first; this PR should then retarget to its base.

## Verification

- solution build: 0 warnings, 0 errors
- generator/unit tests: 344 passed across .NET 8-11
- functional tests: 764 passed across .NET 8-11
- storage matrix: 196 passed across SQLite, PostgreSQL, SQL Server, and Redis
- dashboard: lint, typecheck, and 24 tests passed
- NuGet pack succeeded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cancellation for individual non-terminal jobs through typed schedulers and the dashboard.
  * Added batch cancellation for all non-terminal batch members.
  * Added dashboard cancel actions with confirmation dialogs, progress states, and error handling.
  * Cancelled jobs are immediately marked as `Cancelled` and protected from stale worker completions.
  * Replaced dashboard job deletion with cancellation; terminal jobs can no longer be deleted through this action.

* **Tests**
  * Added coverage for job, batch, dashboard, active execution, and storage cancellation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->