### PR TITLE
Make dashboard environment restriction configurable

### DIFF
--- a/docs/monitoring-api.md
+++ b/docs/monitoring-api.md
@@ -46,4 +46,4 @@ trace and `JobId + Attempt` log links alongside a stable-job-ID log query across
 
 The global event stream emits `state` events whose `data` contains a `snapshot`, the latest jobs, and the latest batches; the event id is the snapshot's Unix timestamp in milliseconds. Batch streams emit `status` and `graph` events whenever either representation changes. Clients should reconnect or fall back to the corresponding JSON endpoints when SSE is unavailable.
 
-Endpoints use the ASP.NET Core authorization metadata configured on `ImmediateJobsDashboardOptions`. If no policy is supplied, middleware rejects requests outside the `Development` environment.
+Endpoints use the ASP.NET Core authorization metadata configured on `ImmediateJobsDashboardOptions`. If no policy is supplied, middleware rejects requests outside the `Development` environment by default. Call `AllowInAnyEnvironment()` to explicitly disable this environment restriction; prefer `RequireAuthorization(...)` when exposing the dashboard outside a trusted development environment.

--- a/readme.md
+++ b/readme.md
@@ -413,6 +413,8 @@ app.MapImmediateJobsDashboard("/jobs");
 The package serves an embedded SPA plus Immediate.Apis-generated JSON and Server-Sent Events endpoints.
 Immediate.Validations returns `application/problem+json` for invalid route and paging inputs.
 Without an authorization policy, dashboard access is allowed only in the `Development` environment.
+Call `AllowInAnyEnvironment()` to explicitly disable this restriction for custom development
+environments; prefer `RequireAuthorization(...)` whenever the dashboard is exposed outside a trusted environment.
 The dashboard includes batch progress and a live dependency-graph viewer alongside filtered jobs,
 recurring schedule actions, retry, cancellation, and atomic batch deletion. Job search and filters
 are paged on the server in groups of 50; batch members show a link to their workflow.

--- a/src/Immediate.Jobs.Dashboard/ImmediateJobsDashboardEndpointRouteBuilderExtensions.cs
+++ b/src/Immediate.Jobs.Dashboard/ImmediateJobsDashboardEndpointRouteBuilderExtensions.cs
@@ -46,9 +46,11 @@ public static class ImmediateJobsDashboardEndpointRouteBuilderExtensions
 		options.Validate();
 
 		var group = endpoints.MapGroup(prefix).WithTags("Immediate.Jobs Dashboard");
-		_ = options.AuthorizationPolicy is { } policy
-			? group.RequireAuthorization(new AuthorizeAttribute(policy))
-			: group.AddEndpointFilter(new DevelopmentDashboardFilter());
+		if (options.AuthorizationPolicy is { } policy)
+			_ = group.RequireAuthorization(new AuthorizeAttribute(policy));
+		else if (options.RestrictToDevelopmentEnvironment)
+			_ = group.AddEndpointFilter(new DevelopmentDashboardFilter());
+
 		_ = group.AddEndpointFilter(new DashboardValidationFilter());
 
 		_ = group.MapImmediateJobsDashboardEndpoints();

--- a/src/Immediate.Jobs.Dashboard/ImmediateJobsDashboardOptions.cs
+++ b/src/Immediate.Jobs.Dashboard/ImmediateJobsDashboardOptions.cs
@@ -9,8 +9,21 @@ public sealed class ImmediateJobsDashboardOptions
 	/// <value>The interval between consecutive dashboard updates.</value>
 	public TimeSpan UpdateInterval { get; set; } = TimeSpan.FromSeconds(2);
 
+	internal bool RestrictToDevelopmentEnvironment { get; private set; } = true;
 	internal string? AuthorizationPolicy { get; private set; }
 	internal IReadOnlyList<JobTelemetryLinkRegistration> TelemetryLinks => _telemetryLinks;
+
+	/// <summary>Allows dashboard access without an authorization policy in any hosting environment.</summary>
+	/// <remarks>
+	/// This disables the default development-environment restriction. Prefer <see cref="RequireAuthorization"/>
+	/// when exposing the dashboard outside a trusted development environment.
+	/// </remarks>
+	/// <returns>This options instance.</returns>
+	public ImmediateJobsDashboardOptions AllowInAnyEnvironment()
+	{
+		RestrictToDevelopmentEnvironment = false;
+		return this;
+	}
 
 	/// <summary>Requires the named ASP.NET Core authorization policy on every dashboard endpoint.</summary>
 	/// <param name="policy">The registered authorization policy name.</param>

--- a/tests/Immediate.Jobs.FunctionalTests/Packages/DashboardPackageTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/Packages/DashboardPackageTests.cs
@@ -35,6 +35,40 @@ public sealed class DashboardPackageTests
 		));
 	}
 
+	[Theory]
+	[InlineData("Development", false, HttpStatusCode.Redirect)]
+	[InlineData("Local", false, HttpStatusCode.Forbidden)]
+	[InlineData("Local", true, HttpStatusCode.Redirect)]
+	public async Task DashboardEnvironmentRestrictionIsConfigurable(
+		string environmentName,
+		bool allowInAnyEnvironment,
+		HttpStatusCode expectedStatus
+	)
+	{
+		var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+		{
+			EnvironmentName = environmentName,
+		});
+		_ = builder.WebHost.UseTestServer();
+		_ = builder.Services.AddImmediateJobsDashboard(options =>
+		{
+			if (allowInAnyEnvironment)
+				_ = options.AllowInAnyEnvironment();
+		});
+		_ = builder.Services.AddSingleton<IJobStorage>(static _ => new InMemoryJobStorage(TimeProvider.System));
+
+		await using var app = builder.Build();
+		_ = app.MapImmediateJobsDashboard();
+		await app.StartAsync(TestContext.Current.CancellationToken);
+
+		using var response = await app.GetTestClient().GetAsync(
+			new Uri("/jobs", UriKind.Relative),
+			TestContext.Current.CancellationToken
+		);
+
+		Assert.Equal(expectedStatus, response.StatusCode);
+	}
+
 	[Fact]
 	public async Task JobAndExecutionTelemetryApisSupplyTheExpectedCallbackContext()
 	{


### PR DESCRIPTION
## Summary

- add an explicit `AllowInAnyEnvironment()` dashboard option
- preserve Development-only access by default and keep authorization policies authoritative
- document the opt-in and cover Development, restricted custom-environment, and allowed custom-environment behavior

## Testing

- `dotnet test tests/Immediate.Jobs.FunctionalTests/Immediate.Jobs.FunctionalTests.csproj --no-restore` (780 tests across net8.0, net9.0, net10.0, and net11.0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to allow the dashboard to run outside the Development environment.
  * Dashboard authorization policies now work independently from environment restrictions.
  * Environment restrictions remain enabled by default.

* **Bug Fixes**
  * Corrected dashboard access behavior when authorization is not configured.

* **Documentation**
  * Updated guidance on environment restrictions and recommended authorization for dashboards exposed beyond trusted development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->