### PR TITLE
Add support for triggering recurring jobs by name

### DIFF
--- a/src/Immediate.Jobs.Generators/ImmediateJobsGenerator.Render.cs
+++ b/src/Immediate.Jobs.Generators/ImmediateJobsGenerator.Render.cs
@@ -57,19 +57,6 @@ public sealed partial class ImmediateJobsGenerator
 		var cancellationToken = context.CancellationToken;
 		cancellationToken.ThrowIfCancellationRequested();
 
-		// Two jobs resolving to the same name would collide at runtime; drop them from
-		// generation and let the analyzer surface the duplicate as a diagnostic instead.
-		var duplicateNames = jobs
-			.GroupBy(job => job.Name, StringComparer.Ordinal)
-			.Where(group => group.Count() > 1)
-			.Select(group => group.Key)
-			.ToImmutableHashSet(StringComparer.Ordinal);
-
-		var models = jobs
-			.Where(job => !duplicateNames.Contains(job.Name))
-			.OrderBy(job => job.TypeName, StringComparer.Ordinal)
-			.ToImmutableArray();
-
 		var model = new
 		{
 			assemblyDefaults.AssemblyName,
@@ -77,14 +64,7 @@ public sealed partial class ImmediateJobsGenerator
 			Namespace = @namespace,
 
 			Queues = queues
-				.Concat(models.Select(job => new QueueModel
-				{
-					Name = job.QueueName,
-					Priority = job.QueuePriority,
-					Concurrency = job.QueueConcurrency,
-				}))
 				.Where(static queue => !string.Equals(queue.Name, "default", StringComparison.Ordinal))
-				.Distinct()
 				.OrderBy(static queue => queue.Name, StringComparer.Ordinal)
 				.Select(queue => new
 				{
@@ -92,9 +72,19 @@ public sealed partial class ImmediateJobsGenerator
 					Priority = queue.Priority.ToString(CultureInfo.InvariantCulture),
 					Concurrency = queue.Concurrency.ToString(CultureInfo.InvariantCulture),
 				})
-				.ToArray(),
+				.ToList(),
 
-			JobsByTag = models.GroupBy(job => job.Tags, StringComparer.Ordinal),
+			Jobs = jobs
+				.Where(job => !job.HasPayload)
+				.Select(job => new
+				{
+					job.TypeName,
+					JobNameLiteral = job.Name.AsCSharpLiteral(),
+				})
+				.ToList(),
+
+			JobsByTag = jobs.GroupBy(job => job.Tags, StringComparer.Ordinal),
+
 			Version = ThisAssembly.InformationalVersion,
 		};
 

--- a/src/Immediate.Jobs.Generators/Templates/Job.sbntxt
+++ b/src/Immediate.Jobs.Generators/Templates/Job.sbntxt
@@ -83,14 +83,16 @@ partial class {{ class_name }}
 			if (execution.Record.Context is { } envelope)
 			{
 				var contextSlices = global::Immediate.Jobs.Shared.JobContextEnvelope.Read(envelope);
-				{{ for context in contexts }}
+
+				{{~ for context in contexts ~}}
 				var contextExtractor{{ context.index }} = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<{{ context.extractor_type_name }}>(scopedServices);
 				if (contextSlices.Remove(contextExtractor{{ context.index }}.Key, out var serializedContext{{ context.index }}))
 				{
 					var context{{ context.index }} = serializer.Deserialize(serializedContext{{ context.index }}, static options => new PayloadJsonContext(options).{{ context.json_property_name }});
 					contextExtractor{{ context.index }}.Restore(context{{ context.index }});
 				}
-				{{ end }}
+
+				{{~ end ~}}
 				global::Immediate.Jobs.Shared.JobContextEnvelope.LogOrphanedSlices(scopedServices, execution.Record, contextSlices.Keys);
 			}
 			{{~ end ~}}
@@ -130,8 +132,11 @@ partial class {{ class_name }}
 		{{~ end ~}}
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Immediate.Jobs", "{{ version }}")]
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Immediate.Jobs", "{{ version }}")]
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = {{ job_name_literal }},
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -280,19 +285,30 @@ partial class {{ class_name }}
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				{{ class_name }}.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>({{ class_name }}.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof({{ class_name }}.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof({{ class_name }}.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<{{ class_name }}.Scheduler>(services);
+
+		{{~ if has_payload ~}}
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Scoped<
+				global::Immediate.Jobs.Shared.IJobScheduler<{{ payload_type_name }}>,
+				{{ class_name }}.Scheduler
+			>(global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<{{ class_name }}.Scheduler>)
+		);
+
+		{{~ end ~}}
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<{{ class_name }}.Invoker>(services);
 
 		{{~ for context in contexts ~}}
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof({{ context.extractor_type_name }}));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<{{ context.extractor_type_name }}>(services);
 		{{~ end ~}}
 
 		return services;

--- a/src/Immediate.Jobs.Generators/Templates/ServiceCollectionExtensions.sbntxt
+++ b/src/Immediate.Jobs.Generators/Templates/ServiceCollectionExtensions.sbntxt
@@ -17,9 +17,13 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 	)
 	{
 		var builder = global::Immediate.Jobs.Shared.ImmediateJobsRuntimeServiceCollectionExtensions.AddImmediateJobsCore(services, configure);
+		
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<
+			global::{{ if !string.empty namespace; namespace; "."; end }}RecurringJobs
+		>(services);
 
 		{{~ for queue in queues ~}}
-		global::Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton(
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(
 			services,
 			new global::Immediate.Jobs.Shared.JobQueueDefinition
 			{
@@ -28,17 +32,20 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 				Concurrency = {{ queue.concurrency }},
 			}
 		);
+
 		{{~ end ~}}
 		{{~ for group in jobs_by_tag ~}}
 		{{~ if group.key != null ~}}
 		if (tags is [] || Intersects(tags, [{{ group.key }}]))
 		{
-		{{~ end ~}}
+			{{~ for job in group ~}}
+			{{ job.type_name }}.AddJob(services);
+			{{~ end ~}}
+		}
+		{{~ else ~}}
 		{{~ for job in group ~}}
 		{{ job.type_name }}.AddJob(services);
 		{{~ end ~}}
-		{{~ if group.key != null ~}}
-		}
 		{{~ end ~}}
 
 		{{~ end ~}}
@@ -61,5 +68,48 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 		}
 
 		return false;
+	}
+}
+
+[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Immediate.Jobs", "{{ version }}")]
+public sealed class RecurringJobs
+{
+	public RecurringJobs(global::System.IServiceProvider serviceProvider)
+	{
+		_serviceProvider = serviceProvider;
+		_jobsByName = 
+			new(global::System.StringComparer.Ordinal)
+			{
+				{{~ for job in jobs ~}}
+				[{{ job.job_name_literal }}] = TriggerCore<{{ job.type_name }}.Scheduler>,
+				{{~ end ~}}
+			};
+	}
+
+	private readonly global::System.IServiceProvider _serviceProvider;
+	private readonly global::System.Collections.Generic.Dictionary<
+		string,
+		global::System.Func<global::System.Threading.CancellationToken, global::System.Threading.Tasks.ValueTask>
+	> _jobsByName;
+
+	private async global::System.Threading.Tasks.ValueTask TriggerCore<T>(global::System.Threading.CancellationToken token)
+		where T : global::Immediate.Jobs.Shared.IRecurringJobTrigger
+	{
+		await using var scope = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.CreateAsyncScope(_serviceProvider);
+
+		var scheduler = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetService<T>(scope.ServiceProvider);
+
+		if (scheduler is null)
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{typeof(T).Name}' was not registered.");
+
+		await scheduler.TriggerNowAsync(token).ConfigureAwait(false);
+	}
+
+	public async global::System.Threading.Tasks.ValueTask TriggerNowAsync(string name, global::System.Threading.CancellationToken cancellationToken = default)
+	{
+		if (!_jobsByName.TryGetValue(name, out var job))
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{name}' was not found.");
+
+		await job(cancellationToken).ConfigureAwait(false);
 	}
 }

--- a/src/Immediate.Jobs.Shared/JobModels.cs
+++ b/src/Immediate.Jobs.Shared/JobModels.cs
@@ -162,7 +162,7 @@ public sealed record RecurringJobSchedule
 }
 
 /// <summary>Immutable generated execution settings.</summary>
-public sealed record JobDefinition
+public record JobDefinition
 {
 	/// <summary>The queue used by newly-created invocations.</summary>
 	/// <value>The queue definition used by new invocations.</value>

--- a/src/Immediate.Jobs.Shared/JobModels.cs
+++ b/src/Immediate.Jobs.Shared/JobModels.cs
@@ -162,6 +162,7 @@ public sealed record RecurringJobSchedule
 }
 
 /// <summary>Immutable generated execution settings.</summary>
+[SuppressMessage("Design", "MA0053", Justification = "Inherited by each job to ensure idempotency in registrations")]
 public record JobDefinition
 {
 	/// <summary>The queue used by newly-created invocations.</summary>

--- a/src/Immediate.Jobs.Shared/JobSchedulers.cs
+++ b/src/Immediate.Jobs.Shared/JobSchedulers.cs
@@ -135,12 +135,10 @@ public abstract class JobScheduler<TPayload>(
 	protected TimeProvider TimeProvider { get; } = timeProvider;
 
 	/// <summary>The stable generated name.</summary>
-	/// <value>The generated job name.</value>
-	protected string JobName { get; } = jobName;
+	public string JobName { get; } = jobName;
 
 	/// <summary>The stable queue used for new invocations.</summary>
-	/// <value>The queue name.</value>
-	protected string QueueName { get; } = queueName;
+	public string QueueName { get; } = queueName;
 
 	/// <inheritdoc />
 	public ValueTask CancelAsync(JobHandle handle, CancellationToken cancellationToken = default)

--- a/tests/Immediate.Jobs.FunctionalTests/GeneratedJobTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/GeneratedJobTests.cs
@@ -284,6 +284,51 @@ public sealed class GeneratedJobTests
 		Assert.Empty(state.Details);
 		Assert.Equal(JobState.Succeeded, (await harness.GetJobAsync(id, cancellationToken)).State);
 	}
+
+	[Fact]
+	public async Task RepeatedRegistrationsOfJobAreIdempotent()
+	{
+		var services = new ServiceCollection();
+
+		_ = PlainRequestJob.AddJob(services);
+
+		Assert.Collection(
+			services,
+			d => Assert.Equal(typeof(JobDefinition), d.ServiceType),
+			d => Assert.Equal(typeof(PlainRequestJob.Scheduler), d.ServiceType),
+			d => Assert.Equal(typeof(IJobScheduler<PlainRequestJob.Payload>), d.ServiceType),
+			d => Assert.Equal(typeof(PlainRequestJob.Invoker), d.ServiceType)
+		);
+
+		_ = RecordMessageJob.AddJob(services);
+
+		Assert.Collection(
+			services,
+			d => Assert.Equal(typeof(JobDefinition), d.ServiceType),
+			d => Assert.Equal(typeof(PlainRequestJob.Scheduler), d.ServiceType),
+			d => Assert.Equal(typeof(IJobScheduler<PlainRequestJob.Payload>), d.ServiceType),
+			d => Assert.Equal(typeof(PlainRequestJob.Invoker), d.ServiceType),
+			d => Assert.Equal(typeof(JobDefinition), d.ServiceType),
+			d => Assert.Equal(typeof(RecordMessageJob.Scheduler), d.ServiceType),
+			d => Assert.Equal(typeof(IJobScheduler<RecordMessageJob.Payload>), d.ServiceType),
+			d => Assert.Equal(typeof(RecordMessageJob.Invoker), d.ServiceType)
+		);
+
+		_ = PlainRequestJob.AddJob(services);
+
+		// verify no items were duplicates
+		Assert.Collection(
+			services,
+			d => Assert.Equal(typeof(JobDefinition), d.ServiceType),
+			d => Assert.Equal(typeof(PlainRequestJob.Scheduler), d.ServiceType),
+			d => Assert.Equal(typeof(IJobScheduler<PlainRequestJob.Payload>), d.ServiceType),
+			d => Assert.Equal(typeof(PlainRequestJob.Invoker), d.ServiceType),
+			d => Assert.Equal(typeof(JobDefinition), d.ServiceType),
+			d => Assert.Equal(typeof(RecordMessageJob.Scheduler), d.ServiceType),
+			d => Assert.Equal(typeof(IJobScheduler<RecordMessageJob.Payload>), d.ServiceType),
+			d => Assert.Equal(typeof(RecordMessageJob.Invoker), d.ServiceType)
+		);
+	}
 }
 
 public sealed class ExecutionState

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ServiceCollectionExtensionsUsesQueuesAndTaggedRegistrations_framework=net10.0#IJ..WorkJob.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ServiceCollectionExtensionsUsesQueuesAndTaggedRegistrations_framework=net10.0#IJ..WorkJob.g.verified.cs
@@ -62,14 +62,14 @@ partial class WorkJob
 			if (execution.Record.Context is { } envelope)
 			{
 				var contextSlices = global::Immediate.Jobs.Shared.JobContextEnvelope.Read(envelope);
-				
-								var contextExtractor0 = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<global::WorkContextExtractor>(scopedServices);
-								if (contextSlices.Remove(contextExtractor0.Key, out var serializedContext0))
-								{
-									var context0 = serializer.Deserialize(serializedContext0, static options => new PayloadJsonContext(options).Context0);
-									contextExtractor0.Restore(context0);
-								}
-								
+
+				var contextExtractor0 = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<global::WorkContextExtractor>(scopedServices);
+				if (contextSlices.Remove(contextExtractor0.Key, out var serializedContext0))
+				{
+					var context0 = serializer.Deserialize(serializedContext0, static options => new PayloadJsonContext(options).Context0);
+					contextExtractor0.Restore(context0);
+				}
+
 				global::Immediate.Jobs.Shared.JobContextEnvelope.LogOrphanedSlices(scopedServices, execution.Record, contextSlices.Keys);
 			}
 
@@ -100,8 +100,9 @@ partial class WorkJob
 			where TRequest : global::Immediate.Jobs.Shared.IJobRequest => request.JobDetails = details;
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = "work",
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -177,18 +178,19 @@ partial class WorkJob
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				WorkJob.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>(WorkJob.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(WorkJob.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof(WorkJob.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<WorkJob.Scheduler>(services);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(global::WorkContextExtractor));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<WorkJob.Invoker>(services);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<global::WorkContextExtractor>(services);
 
 		return services;
 	}

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ServiceCollectionExtensionsUsesQueuesAndTaggedRegistrations_framework=net10.0#IJ.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ServiceCollectionExtensionsUsesQueuesAndTaggedRegistrations_framework=net10.0#IJ.ServiceCollectionExtensions.g.verified.cs
@@ -15,8 +15,12 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 	)
 	{
 		var builder = global::Immediate.Jobs.Shared.ImmediateJobsRuntimeServiceCollectionExtensions.AddImmediateJobsCore(services, configure);
+		
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<
+			global::Immediate.Jobs.Testing.RecurringJobs
+		>(services);
 
-		global::Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton(
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(
 			services,
 			new global::Immediate.Jobs.Shared.JobQueueDefinition
 			{
@@ -25,9 +29,10 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 				Concurrency = 1,
 			}
 		);
+
 		if (tags is [] || Intersects(tags, ["critical"]))
 		{
-		global::WorkJob.AddJob(services);
+			global::WorkJob.AddJob(services);
 		}
 
 		return builder;
@@ -49,5 +54,45 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 		}
 
 		return false;
+	}
+}
+
+public sealed class RecurringJobs
+{
+	public RecurringJobs(global::System.IServiceProvider serviceProvider)
+	{
+		_serviceProvider = serviceProvider;
+		_jobsByName = 
+			new(global::System.StringComparer.Ordinal)
+			{
+				["work"] = TriggerCore<global::WorkJob.Scheduler>,
+			};
+	}
+
+	private readonly global::System.IServiceProvider _serviceProvider;
+	private readonly global::System.Collections.Generic.Dictionary<
+		string,
+		global::System.Func<global::System.Threading.CancellationToken, global::System.Threading.Tasks.ValueTask>
+	> _jobsByName;
+
+	private async global::System.Threading.Tasks.ValueTask TriggerCore<T>(global::System.Threading.CancellationToken token)
+		where T : global::Immediate.Jobs.Shared.IRecurringJobTrigger
+	{
+		await using var scope = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.CreateAsyncScope(_serviceProvider);
+
+		var scheduler = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetService<T>(scope.ServiceProvider);
+
+		if (scheduler is null)
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{typeof(T).Name}' was not registered.");
+
+		await scheduler.TriggerNowAsync(token).ConfigureAwait(false);
+	}
+
+	public async global::System.Threading.Tasks.ValueTask TriggerNowAsync(string name, global::System.Threading.CancellationToken cancellationToken = default)
+	{
+		if (!_jobsByName.TryGetValue(name, out var job))
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{name}' was not found.");
+
+		await job(cancellationToken).ConfigureAwait(false);
 	}
 }

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ServiceCollectionExtensionsUsesQueuesAndTaggedRegistrations_framework=net11.0#IJ..WorkJob.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ServiceCollectionExtensionsUsesQueuesAndTaggedRegistrations_framework=net11.0#IJ..WorkJob.g.verified.cs
@@ -62,14 +62,14 @@ partial class WorkJob
 			if (execution.Record.Context is { } envelope)
 			{
 				var contextSlices = global::Immediate.Jobs.Shared.JobContextEnvelope.Read(envelope);
-				
-								var contextExtractor0 = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<global::WorkContextExtractor>(scopedServices);
-								if (contextSlices.Remove(contextExtractor0.Key, out var serializedContext0))
-								{
-									var context0 = serializer.Deserialize(serializedContext0, static options => new PayloadJsonContext(options).Context0);
-									contextExtractor0.Restore(context0);
-								}
-								
+
+				var contextExtractor0 = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<global::WorkContextExtractor>(scopedServices);
+				if (contextSlices.Remove(contextExtractor0.Key, out var serializedContext0))
+				{
+					var context0 = serializer.Deserialize(serializedContext0, static options => new PayloadJsonContext(options).Context0);
+					contextExtractor0.Restore(context0);
+				}
+
 				global::Immediate.Jobs.Shared.JobContextEnvelope.LogOrphanedSlices(scopedServices, execution.Record, contextSlices.Keys);
 			}
 
@@ -100,8 +100,9 @@ partial class WorkJob
 			where TRequest : global::Immediate.Jobs.Shared.IJobRequest => request.JobDetails = details;
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = "work",
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -177,18 +178,19 @@ partial class WorkJob
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				WorkJob.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>(WorkJob.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(WorkJob.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof(WorkJob.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<WorkJob.Scheduler>(services);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(global::WorkContextExtractor));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<WorkJob.Invoker>(services);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<global::WorkContextExtractor>(services);
 
 		return services;
 	}

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ServiceCollectionExtensionsUsesQueuesAndTaggedRegistrations_framework=net11.0#IJ.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ServiceCollectionExtensionsUsesQueuesAndTaggedRegistrations_framework=net11.0#IJ.ServiceCollectionExtensions.g.verified.cs
@@ -15,8 +15,12 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 	)
 	{
 		var builder = global::Immediate.Jobs.Shared.ImmediateJobsRuntimeServiceCollectionExtensions.AddImmediateJobsCore(services, configure);
+		
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<
+			global::Immediate.Jobs.Testing.RecurringJobs
+		>(services);
 
-		global::Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton(
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(
 			services,
 			new global::Immediate.Jobs.Shared.JobQueueDefinition
 			{
@@ -25,9 +29,10 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 				Concurrency = 1,
 			}
 		);
+
 		if (tags is [] || Intersects(tags, ["critical"]))
 		{
-		global::WorkJob.AddJob(services);
+			global::WorkJob.AddJob(services);
 		}
 
 		return builder;
@@ -49,5 +54,45 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 		}
 
 		return false;
+	}
+}
+
+public sealed class RecurringJobs
+{
+	public RecurringJobs(global::System.IServiceProvider serviceProvider)
+	{
+		_serviceProvider = serviceProvider;
+		_jobsByName = 
+			new(global::System.StringComparer.Ordinal)
+			{
+				["work"] = TriggerCore<global::WorkJob.Scheduler>,
+			};
+	}
+
+	private readonly global::System.IServiceProvider _serviceProvider;
+	private readonly global::System.Collections.Generic.Dictionary<
+		string,
+		global::System.Func<global::System.Threading.CancellationToken, global::System.Threading.Tasks.ValueTask>
+	> _jobsByName;
+
+	private async global::System.Threading.Tasks.ValueTask TriggerCore<T>(global::System.Threading.CancellationToken token)
+		where T : global::Immediate.Jobs.Shared.IRecurringJobTrigger
+	{
+		await using var scope = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.CreateAsyncScope(_serviceProvider);
+
+		var scheduler = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetService<T>(scope.ServiceProvider);
+
+		if (scheduler is null)
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{typeof(T).Name}' was not registered.");
+
+		await scheduler.TriggerNowAsync(token).ConfigureAwait(false);
+	}
+
+	public async global::System.Threading.Tasks.ValueTask TriggerNowAsync(string name, global::System.Threading.CancellationToken cancellationToken = default)
+	{
+		if (!_jobsByName.TryGetValue(name, out var job))
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{name}' was not found.");
+
+		await job(cancellationToken).ConfigureAwait(false);
 	}
 }

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ServiceCollectionExtensionsUsesQueuesAndTaggedRegistrations_framework=net8.0#IJ..WorkJob.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ServiceCollectionExtensionsUsesQueuesAndTaggedRegistrations_framework=net8.0#IJ..WorkJob.g.verified.cs
@@ -62,14 +62,14 @@ partial class WorkJob
 			if (execution.Record.Context is { } envelope)
 			{
 				var contextSlices = global::Immediate.Jobs.Shared.JobContextEnvelope.Read(envelope);
-				
-								var contextExtractor0 = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<global::WorkContextExtractor>(scopedServices);
-								if (contextSlices.Remove(contextExtractor0.Key, out var serializedContext0))
-								{
-									var context0 = serializer.Deserialize(serializedContext0, static options => new PayloadJsonContext(options).Context0);
-									contextExtractor0.Restore(context0);
-								}
-								
+
+				var contextExtractor0 = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<global::WorkContextExtractor>(scopedServices);
+				if (contextSlices.Remove(contextExtractor0.Key, out var serializedContext0))
+				{
+					var context0 = serializer.Deserialize(serializedContext0, static options => new PayloadJsonContext(options).Context0);
+					contextExtractor0.Restore(context0);
+				}
+
 				global::Immediate.Jobs.Shared.JobContextEnvelope.LogOrphanedSlices(scopedServices, execution.Record, contextSlices.Keys);
 			}
 
@@ -100,8 +100,9 @@ partial class WorkJob
 			where TRequest : global::Immediate.Jobs.Shared.IJobRequest => request.JobDetails = details;
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = "work",
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -177,18 +178,19 @@ partial class WorkJob
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				WorkJob.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>(WorkJob.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(WorkJob.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof(WorkJob.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<WorkJob.Scheduler>(services);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(global::WorkContextExtractor));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<WorkJob.Invoker>(services);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<global::WorkContextExtractor>(services);
 
 		return services;
 	}

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ServiceCollectionExtensionsUsesQueuesAndTaggedRegistrations_framework=net8.0#IJ.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ServiceCollectionExtensionsUsesQueuesAndTaggedRegistrations_framework=net8.0#IJ.ServiceCollectionExtensions.g.verified.cs
@@ -15,8 +15,12 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 	)
 	{
 		var builder = global::Immediate.Jobs.Shared.ImmediateJobsRuntimeServiceCollectionExtensions.AddImmediateJobsCore(services, configure);
+		
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<
+			global::Immediate.Jobs.Testing.RecurringJobs
+		>(services);
 
-		global::Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton(
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(
 			services,
 			new global::Immediate.Jobs.Shared.JobQueueDefinition
 			{
@@ -25,9 +29,10 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 				Concurrency = 1,
 			}
 		);
+
 		if (tags is [] || Intersects(tags, ["critical"]))
 		{
-		global::WorkJob.AddJob(services);
+			global::WorkJob.AddJob(services);
 		}
 
 		return builder;
@@ -49,5 +54,45 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 		}
 
 		return false;
+	}
+}
+
+public sealed class RecurringJobs
+{
+	public RecurringJobs(global::System.IServiceProvider serviceProvider)
+	{
+		_serviceProvider = serviceProvider;
+		_jobsByName = 
+			new(global::System.StringComparer.Ordinal)
+			{
+				["work"] = TriggerCore<global::WorkJob.Scheduler>,
+			};
+	}
+
+	private readonly global::System.IServiceProvider _serviceProvider;
+	private readonly global::System.Collections.Generic.Dictionary<
+		string,
+		global::System.Func<global::System.Threading.CancellationToken, global::System.Threading.Tasks.ValueTask>
+	> _jobsByName;
+
+	private async global::System.Threading.Tasks.ValueTask TriggerCore<T>(global::System.Threading.CancellationToken token)
+		where T : global::Immediate.Jobs.Shared.IRecurringJobTrigger
+	{
+		await using var scope = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.CreateAsyncScope(_serviceProvider);
+
+		var scheduler = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetService<T>(scope.ServiceProvider);
+
+		if (scheduler is null)
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{typeof(T).Name}' was not registered.");
+
+		await scheduler.TriggerNowAsync(token).ConfigureAwait(false);
+	}
+
+	public async global::System.Threading.Tasks.ValueTask TriggerNowAsync(string name, global::System.Threading.CancellationToken cancellationToken = default)
+	{
+		if (!_jobsByName.TryGetValue(name, out var job))
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{name}' was not found.");
+
+		await job(cancellationToken).ConfigureAwait(false);
 	}
 }

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ServiceCollectionExtensionsUsesQueuesAndTaggedRegistrations_framework=net9.0#IJ..WorkJob.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ServiceCollectionExtensionsUsesQueuesAndTaggedRegistrations_framework=net9.0#IJ..WorkJob.g.verified.cs
@@ -62,14 +62,14 @@ partial class WorkJob
 			if (execution.Record.Context is { } envelope)
 			{
 				var contextSlices = global::Immediate.Jobs.Shared.JobContextEnvelope.Read(envelope);
-				
-								var contextExtractor0 = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<global::WorkContextExtractor>(scopedServices);
-								if (contextSlices.Remove(contextExtractor0.Key, out var serializedContext0))
-								{
-									var context0 = serializer.Deserialize(serializedContext0, static options => new PayloadJsonContext(options).Context0);
-									contextExtractor0.Restore(context0);
-								}
-								
+
+				var contextExtractor0 = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<global::WorkContextExtractor>(scopedServices);
+				if (contextSlices.Remove(contextExtractor0.Key, out var serializedContext0))
+				{
+					var context0 = serializer.Deserialize(serializedContext0, static options => new PayloadJsonContext(options).Context0);
+					contextExtractor0.Restore(context0);
+				}
+
 				global::Immediate.Jobs.Shared.JobContextEnvelope.LogOrphanedSlices(scopedServices, execution.Record, contextSlices.Keys);
 			}
 
@@ -100,8 +100,9 @@ partial class WorkJob
 			where TRequest : global::Immediate.Jobs.Shared.IJobRequest => request.JobDetails = details;
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = "work",
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -177,18 +178,19 @@ partial class WorkJob
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				WorkJob.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>(WorkJob.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(WorkJob.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof(WorkJob.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<WorkJob.Scheduler>(services);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(global::WorkContextExtractor));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<WorkJob.Invoker>(services);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<global::WorkContextExtractor>(services);
 
 		return services;
 	}

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ServiceCollectionExtensionsUsesQueuesAndTaggedRegistrations_framework=net9.0#IJ.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ServiceCollectionExtensionsUsesQueuesAndTaggedRegistrations_framework=net9.0#IJ.ServiceCollectionExtensions.g.verified.cs
@@ -15,8 +15,12 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 	)
 	{
 		var builder = global::Immediate.Jobs.Shared.ImmediateJobsRuntimeServiceCollectionExtensions.AddImmediateJobsCore(services, configure);
+		
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<
+			global::Immediate.Jobs.Testing.RecurringJobs
+		>(services);
 
-		global::Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton(
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(
 			services,
 			new global::Immediate.Jobs.Shared.JobQueueDefinition
 			{
@@ -25,9 +29,10 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 				Concurrency = 1,
 			}
 		);
+
 		if (tags is [] || Intersects(tags, ["critical"]))
 		{
-		global::WorkJob.AddJob(services);
+			global::WorkJob.AddJob(services);
 		}
 
 		return builder;
@@ -49,5 +54,45 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 		}
 
 		return false;
+	}
+}
+
+public sealed class RecurringJobs
+{
+	public RecurringJobs(global::System.IServiceProvider serviceProvider)
+	{
+		_serviceProvider = serviceProvider;
+		_jobsByName = 
+			new(global::System.StringComparer.Ordinal)
+			{
+				["work"] = TriggerCore<global::WorkJob.Scheduler>,
+			};
+	}
+
+	private readonly global::System.IServiceProvider _serviceProvider;
+	private readonly global::System.Collections.Generic.Dictionary<
+		string,
+		global::System.Func<global::System.Threading.CancellationToken, global::System.Threading.Tasks.ValueTask>
+	> _jobsByName;
+
+	private async global::System.Threading.Tasks.ValueTask TriggerCore<T>(global::System.Threading.CancellationToken token)
+		where T : global::Immediate.Jobs.Shared.IRecurringJobTrigger
+	{
+		await using var scope = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.CreateAsyncScope(_serviceProvider);
+
+		var scheduler = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetService<T>(scope.ServiceProvider);
+
+		if (scheduler is null)
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{typeof(T).Name}' was not registered.");
+
+		await scheduler.TriggerNowAsync(token).ConfigureAwait(false);
+	}
+
+	public async global::System.Threading.Tasks.ValueTask TriggerNowAsync(string name, global::System.Threading.CancellationToken cancellationToken = default)
+	{
+		if (!_jobsByName.TryGetValue(name, out var job))
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{name}' was not found.");
+
+		await job(cancellationToken).ConfigureAwait(false);
 	}
 }

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ValidAddJobsMethod_framework=net10.0#IJ.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ValidAddJobsMethod_framework=net10.0#IJ.ServiceCollectionExtensions.g.verified.cs
@@ -15,6 +15,10 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 	)
 	{
 		var builder = global::Immediate.Jobs.Shared.ImmediateJobsRuntimeServiceCollectionExtensions.AddImmediateJobsCore(services, configure);
+		
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<
+			global::Immediate.Jobs.Testing.RecurringJobs
+		>(services);
 
 		return builder;
 	}
@@ -35,5 +39,44 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 		}
 
 		return false;
+	}
+}
+
+public sealed class RecurringJobs
+{
+	public RecurringJobs(global::System.IServiceProvider serviceProvider)
+	{
+		_serviceProvider = serviceProvider;
+		_jobsByName = 
+			new(global::System.StringComparer.Ordinal)
+			{
+			};
+	}
+
+	private readonly global::System.IServiceProvider _serviceProvider;
+	private readonly global::System.Collections.Generic.Dictionary<
+		string,
+		global::System.Func<global::System.Threading.CancellationToken, global::System.Threading.Tasks.ValueTask>
+	> _jobsByName;
+
+	private async global::System.Threading.Tasks.ValueTask TriggerCore<T>(global::System.Threading.CancellationToken token)
+		where T : global::Immediate.Jobs.Shared.IRecurringJobTrigger
+	{
+		await using var scope = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.CreateAsyncScope(_serviceProvider);
+
+		var scheduler = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetService<T>(scope.ServiceProvider);
+
+		if (scheduler is null)
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{typeof(T).Name}' was not registered.");
+
+		await scheduler.TriggerNowAsync(token).ConfigureAwait(false);
+	}
+
+	public async global::System.Threading.Tasks.ValueTask TriggerNowAsync(string name, global::System.Threading.CancellationToken cancellationToken = default)
+	{
+		if (!_jobsByName.TryGetValue(name, out var job))
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{name}' was not found.");
+
+		await job(cancellationToken).ConfigureAwait(false);
 	}
 }

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ValidAddJobsMethod_framework=net11.0#IJ.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ValidAddJobsMethod_framework=net11.0#IJ.ServiceCollectionExtensions.g.verified.cs
@@ -15,6 +15,10 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 	)
 	{
 		var builder = global::Immediate.Jobs.Shared.ImmediateJobsRuntimeServiceCollectionExtensions.AddImmediateJobsCore(services, configure);
+		
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<
+			global::Immediate.Jobs.Testing.RecurringJobs
+		>(services);
 
 		return builder;
 	}
@@ -35,5 +39,44 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 		}
 
 		return false;
+	}
+}
+
+public sealed class RecurringJobs
+{
+	public RecurringJobs(global::System.IServiceProvider serviceProvider)
+	{
+		_serviceProvider = serviceProvider;
+		_jobsByName = 
+			new(global::System.StringComparer.Ordinal)
+			{
+			};
+	}
+
+	private readonly global::System.IServiceProvider _serviceProvider;
+	private readonly global::System.Collections.Generic.Dictionary<
+		string,
+		global::System.Func<global::System.Threading.CancellationToken, global::System.Threading.Tasks.ValueTask>
+	> _jobsByName;
+
+	private async global::System.Threading.Tasks.ValueTask TriggerCore<T>(global::System.Threading.CancellationToken token)
+		where T : global::Immediate.Jobs.Shared.IRecurringJobTrigger
+	{
+		await using var scope = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.CreateAsyncScope(_serviceProvider);
+
+		var scheduler = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetService<T>(scope.ServiceProvider);
+
+		if (scheduler is null)
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{typeof(T).Name}' was not registered.");
+
+		await scheduler.TriggerNowAsync(token).ConfigureAwait(false);
+	}
+
+	public async global::System.Threading.Tasks.ValueTask TriggerNowAsync(string name, global::System.Threading.CancellationToken cancellationToken = default)
+	{
+		if (!_jobsByName.TryGetValue(name, out var job))
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{name}' was not found.");
+
+		await job(cancellationToken).ConfigureAwait(false);
 	}
 }

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ValidAddJobsMethod_framework=net8.0#IJ.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ValidAddJobsMethod_framework=net8.0#IJ.ServiceCollectionExtensions.g.verified.cs
@@ -15,6 +15,10 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 	)
 	{
 		var builder = global::Immediate.Jobs.Shared.ImmediateJobsRuntimeServiceCollectionExtensions.AddImmediateJobsCore(services, configure);
+		
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<
+			global::Immediate.Jobs.Testing.RecurringJobs
+		>(services);
 
 		return builder;
 	}
@@ -35,5 +39,44 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 		}
 
 		return false;
+	}
+}
+
+public sealed class RecurringJobs
+{
+	public RecurringJobs(global::System.IServiceProvider serviceProvider)
+	{
+		_serviceProvider = serviceProvider;
+		_jobsByName = 
+			new(global::System.StringComparer.Ordinal)
+			{
+			};
+	}
+
+	private readonly global::System.IServiceProvider _serviceProvider;
+	private readonly global::System.Collections.Generic.Dictionary<
+		string,
+		global::System.Func<global::System.Threading.CancellationToken, global::System.Threading.Tasks.ValueTask>
+	> _jobsByName;
+
+	private async global::System.Threading.Tasks.ValueTask TriggerCore<T>(global::System.Threading.CancellationToken token)
+		where T : global::Immediate.Jobs.Shared.IRecurringJobTrigger
+	{
+		await using var scope = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.CreateAsyncScope(_serviceProvider);
+
+		var scheduler = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetService<T>(scope.ServiceProvider);
+
+		if (scheduler is null)
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{typeof(T).Name}' was not registered.");
+
+		await scheduler.TriggerNowAsync(token).ConfigureAwait(false);
+	}
+
+	public async global::System.Threading.Tasks.ValueTask TriggerNowAsync(string name, global::System.Threading.CancellationToken cancellationToken = default)
+	{
+		if (!_jobsByName.TryGetValue(name, out var job))
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{name}' was not found.");
+
+		await job(cancellationToken).ConfigureAwait(false);
 	}
 }

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ValidAddJobsMethod_framework=net9.0#IJ.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/AddJobsTests.ValidAddJobsMethod_framework=net9.0#IJ.ServiceCollectionExtensions.g.verified.cs
@@ -15,6 +15,10 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 	)
 	{
 		var builder = global::Immediate.Jobs.Shared.ImmediateJobsRuntimeServiceCollectionExtensions.AddImmediateJobsCore(services, configure);
+		
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<
+			global::Immediate.Jobs.Testing.RecurringJobs
+		>(services);
 
 		return builder;
 	}
@@ -35,5 +39,44 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 		}
 
 		return false;
+	}
+}
+
+public sealed class RecurringJobs
+{
+	public RecurringJobs(global::System.IServiceProvider serviceProvider)
+	{
+		_serviceProvider = serviceProvider;
+		_jobsByName = 
+			new(global::System.StringComparer.Ordinal)
+			{
+			};
+	}
+
+	private readonly global::System.IServiceProvider _serviceProvider;
+	private readonly global::System.Collections.Generic.Dictionary<
+		string,
+		global::System.Func<global::System.Threading.CancellationToken, global::System.Threading.Tasks.ValueTask>
+	> _jobsByName;
+
+	private async global::System.Threading.Tasks.ValueTask TriggerCore<T>(global::System.Threading.CancellationToken token)
+		where T : global::Immediate.Jobs.Shared.IRecurringJobTrigger
+	{
+		await using var scope = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.CreateAsyncScope(_serviceProvider);
+
+		var scheduler = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetService<T>(scope.ServiceProvider);
+
+		if (scheduler is null)
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{typeof(T).Name}' was not registered.");
+
+		await scheduler.TriggerNowAsync(token).ConfigureAwait(false);
+	}
+
+	public async global::System.Threading.Tasks.ValueTask TriggerNowAsync(string name, global::System.Threading.CancellationToken cancellationToken = default)
+	{
+		if (!_jobsByName.TryGetValue(name, out var job))
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{name}' was not found.");
+
+		await job(cancellationToken).ConfigureAwait(false);
 	}
 }

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateAssemblyIdentifierTests.ImmediateAssemblyIdentifierOverridesAssemblyName_framework=net10.0#IJ.Dummy.GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateAssemblyIdentifierTests.ImmediateAssemblyIdentifierOverridesAssemblyName_framework=net10.0#IJ.Dummy.GetUsersQuery.g.verified.cs
@@ -40,8 +40,9 @@ partial class GetUsersQuery
 		}
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = "get-users-query",
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -102,16 +103,25 @@ partial class GetUsersQuery
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				GetUsersQuery.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>(GetUsersQuery.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(GetUsersQuery.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof(GetUsersQuery.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<GetUsersQuery.Scheduler>(services);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Scoped<
+				global::Immediate.Jobs.Shared.IJobScheduler<global::Dummy.GetUsersQuery.Query>,
+				GetUsersQuery.Scheduler
+			>(global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<GetUsersQuery.Scheduler>)
+		);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<GetUsersQuery.Invoker>(services);
 
 
 		return services;

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateAssemblyIdentifierTests.ImmediateAssemblyIdentifierOverridesAssemblyName_framework=net10.0#IJ.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateAssemblyIdentifierTests.ImmediateAssemblyIdentifierOverridesAssemblyName_framework=net10.0#IJ.ServiceCollectionExtensions.g.verified.cs
@@ -15,6 +15,10 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 	)
 	{
 		var builder = global::Immediate.Jobs.Shared.ImmediateJobsRuntimeServiceCollectionExtensions.AddImmediateJobsCore(services, configure);
+		
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<
+			global::Immediate.Jobs.Testing.RecurringJobs
+		>(services);
 
 		global::Dummy.GetUsersQuery.AddJob(services);
 
@@ -37,5 +41,44 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 		}
 
 		return false;
+	}
+}
+
+public sealed class RecurringJobs
+{
+	public RecurringJobs(global::System.IServiceProvider serviceProvider)
+	{
+		_serviceProvider = serviceProvider;
+		_jobsByName = 
+			new(global::System.StringComparer.Ordinal)
+			{
+			};
+	}
+
+	private readonly global::System.IServiceProvider _serviceProvider;
+	private readonly global::System.Collections.Generic.Dictionary<
+		string,
+		global::System.Func<global::System.Threading.CancellationToken, global::System.Threading.Tasks.ValueTask>
+	> _jobsByName;
+
+	private async global::System.Threading.Tasks.ValueTask TriggerCore<T>(global::System.Threading.CancellationToken token)
+		where T : global::Immediate.Jobs.Shared.IRecurringJobTrigger
+	{
+		await using var scope = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.CreateAsyncScope(_serviceProvider);
+
+		var scheduler = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetService<T>(scope.ServiceProvider);
+
+		if (scheduler is null)
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{typeof(T).Name}' was not registered.");
+
+		await scheduler.TriggerNowAsync(token).ConfigureAwait(false);
+	}
+
+	public async global::System.Threading.Tasks.ValueTask TriggerNowAsync(string name, global::System.Threading.CancellationToken cancellationToken = default)
+	{
+		if (!_jobsByName.TryGetValue(name, out var job))
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{name}' was not found.");
+
+		await job(cancellationToken).ConfigureAwait(false);
 	}
 }

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateAssemblyIdentifierTests.ImmediateAssemblyIdentifierOverridesAssemblyName_framework=net11.0#IJ.Dummy.GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateAssemblyIdentifierTests.ImmediateAssemblyIdentifierOverridesAssemblyName_framework=net11.0#IJ.Dummy.GetUsersQuery.g.verified.cs
@@ -40,8 +40,9 @@ partial class GetUsersQuery
 		}
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = "get-users-query",
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -102,16 +103,25 @@ partial class GetUsersQuery
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				GetUsersQuery.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>(GetUsersQuery.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(GetUsersQuery.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof(GetUsersQuery.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<GetUsersQuery.Scheduler>(services);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Scoped<
+				global::Immediate.Jobs.Shared.IJobScheduler<global::Dummy.GetUsersQuery.Query>,
+				GetUsersQuery.Scheduler
+			>(global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<GetUsersQuery.Scheduler>)
+		);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<GetUsersQuery.Invoker>(services);
 
 
 		return services;

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateAssemblyIdentifierTests.ImmediateAssemblyIdentifierOverridesAssemblyName_framework=net11.0#IJ.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateAssemblyIdentifierTests.ImmediateAssemblyIdentifierOverridesAssemblyName_framework=net11.0#IJ.ServiceCollectionExtensions.g.verified.cs
@@ -15,6 +15,10 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 	)
 	{
 		var builder = global::Immediate.Jobs.Shared.ImmediateJobsRuntimeServiceCollectionExtensions.AddImmediateJobsCore(services, configure);
+		
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<
+			global::Immediate.Jobs.Testing.RecurringJobs
+		>(services);
 
 		global::Dummy.GetUsersQuery.AddJob(services);
 
@@ -37,5 +41,44 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 		}
 
 		return false;
+	}
+}
+
+public sealed class RecurringJobs
+{
+	public RecurringJobs(global::System.IServiceProvider serviceProvider)
+	{
+		_serviceProvider = serviceProvider;
+		_jobsByName = 
+			new(global::System.StringComparer.Ordinal)
+			{
+			};
+	}
+
+	private readonly global::System.IServiceProvider _serviceProvider;
+	private readonly global::System.Collections.Generic.Dictionary<
+		string,
+		global::System.Func<global::System.Threading.CancellationToken, global::System.Threading.Tasks.ValueTask>
+	> _jobsByName;
+
+	private async global::System.Threading.Tasks.ValueTask TriggerCore<T>(global::System.Threading.CancellationToken token)
+		where T : global::Immediate.Jobs.Shared.IRecurringJobTrigger
+	{
+		await using var scope = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.CreateAsyncScope(_serviceProvider);
+
+		var scheduler = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetService<T>(scope.ServiceProvider);
+
+		if (scheduler is null)
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{typeof(T).Name}' was not registered.");
+
+		await scheduler.TriggerNowAsync(token).ConfigureAwait(false);
+	}
+
+	public async global::System.Threading.Tasks.ValueTask TriggerNowAsync(string name, global::System.Threading.CancellationToken cancellationToken = default)
+	{
+		if (!_jobsByName.TryGetValue(name, out var job))
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{name}' was not found.");
+
+		await job(cancellationToken).ConfigureAwait(false);
 	}
 }

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateAssemblyIdentifierTests.ImmediateAssemblyIdentifierOverridesAssemblyName_framework=net8.0#IJ.Dummy.GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateAssemblyIdentifierTests.ImmediateAssemblyIdentifierOverridesAssemblyName_framework=net8.0#IJ.Dummy.GetUsersQuery.g.verified.cs
@@ -40,8 +40,9 @@ partial class GetUsersQuery
 		}
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = "get-users-query",
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -102,16 +103,25 @@ partial class GetUsersQuery
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				GetUsersQuery.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>(GetUsersQuery.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(GetUsersQuery.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof(GetUsersQuery.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<GetUsersQuery.Scheduler>(services);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Scoped<
+				global::Immediate.Jobs.Shared.IJobScheduler<global::Dummy.GetUsersQuery.Query>,
+				GetUsersQuery.Scheduler
+			>(global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<GetUsersQuery.Scheduler>)
+		);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<GetUsersQuery.Invoker>(services);
 
 
 		return services;

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateAssemblyIdentifierTests.ImmediateAssemblyIdentifierOverridesAssemblyName_framework=net8.0#IJ.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateAssemblyIdentifierTests.ImmediateAssemblyIdentifierOverridesAssemblyName_framework=net8.0#IJ.ServiceCollectionExtensions.g.verified.cs
@@ -15,6 +15,10 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 	)
 	{
 		var builder = global::Immediate.Jobs.Shared.ImmediateJobsRuntimeServiceCollectionExtensions.AddImmediateJobsCore(services, configure);
+		
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<
+			global::Immediate.Jobs.Testing.RecurringJobs
+		>(services);
 
 		global::Dummy.GetUsersQuery.AddJob(services);
 
@@ -37,5 +41,44 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 		}
 
 		return false;
+	}
+}
+
+public sealed class RecurringJobs
+{
+	public RecurringJobs(global::System.IServiceProvider serviceProvider)
+	{
+		_serviceProvider = serviceProvider;
+		_jobsByName = 
+			new(global::System.StringComparer.Ordinal)
+			{
+			};
+	}
+
+	private readonly global::System.IServiceProvider _serviceProvider;
+	private readonly global::System.Collections.Generic.Dictionary<
+		string,
+		global::System.Func<global::System.Threading.CancellationToken, global::System.Threading.Tasks.ValueTask>
+	> _jobsByName;
+
+	private async global::System.Threading.Tasks.ValueTask TriggerCore<T>(global::System.Threading.CancellationToken token)
+		where T : global::Immediate.Jobs.Shared.IRecurringJobTrigger
+	{
+		await using var scope = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.CreateAsyncScope(_serviceProvider);
+
+		var scheduler = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetService<T>(scope.ServiceProvider);
+
+		if (scheduler is null)
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{typeof(T).Name}' was not registered.");
+
+		await scheduler.TriggerNowAsync(token).ConfigureAwait(false);
+	}
+
+	public async global::System.Threading.Tasks.ValueTask TriggerNowAsync(string name, global::System.Threading.CancellationToken cancellationToken = default)
+	{
+		if (!_jobsByName.TryGetValue(name, out var job))
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{name}' was not found.");
+
+		await job(cancellationToken).ConfigureAwait(false);
 	}
 }

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateAssemblyIdentifierTests.ImmediateAssemblyIdentifierOverridesAssemblyName_framework=net9.0#IJ.Dummy.GetUsersQuery.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateAssemblyIdentifierTests.ImmediateAssemblyIdentifierOverridesAssemblyName_framework=net9.0#IJ.Dummy.GetUsersQuery.g.verified.cs
@@ -40,8 +40,9 @@ partial class GetUsersQuery
 		}
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = "get-users-query",
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -102,16 +103,25 @@ partial class GetUsersQuery
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				GetUsersQuery.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>(GetUsersQuery.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(GetUsersQuery.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof(GetUsersQuery.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<GetUsersQuery.Scheduler>(services);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Scoped<
+				global::Immediate.Jobs.Shared.IJobScheduler<global::Dummy.GetUsersQuery.Query>,
+				GetUsersQuery.Scheduler
+			>(global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<GetUsersQuery.Scheduler>)
+		);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<GetUsersQuery.Invoker>(services);
 
 
 		return services;

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateAssemblyIdentifierTests.ImmediateAssemblyIdentifierOverridesAssemblyName_framework=net9.0#IJ.ServiceCollectionExtensions.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateAssemblyIdentifierTests.ImmediateAssemblyIdentifierOverridesAssemblyName_framework=net9.0#IJ.ServiceCollectionExtensions.g.verified.cs
@@ -15,6 +15,10 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 	)
 	{
 		var builder = global::Immediate.Jobs.Shared.ImmediateJobsRuntimeServiceCollectionExtensions.AddImmediateJobsCore(services, configure);
+		
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<
+			global::Immediate.Jobs.Testing.RecurringJobs
+		>(services);
 
 		global::Dummy.GetUsersQuery.AddJob(services);
 
@@ -37,5 +41,44 @@ public static class ImmediateJobsGeneratedServiceCollectionExtensions
 		}
 
 		return false;
+	}
+}
+
+public sealed class RecurringJobs
+{
+	public RecurringJobs(global::System.IServiceProvider serviceProvider)
+	{
+		_serviceProvider = serviceProvider;
+		_jobsByName = 
+			new(global::System.StringComparer.Ordinal)
+			{
+			};
+	}
+
+	private readonly global::System.IServiceProvider _serviceProvider;
+	private readonly global::System.Collections.Generic.Dictionary<
+		string,
+		global::System.Func<global::System.Threading.CancellationToken, global::System.Threading.Tasks.ValueTask>
+	> _jobsByName;
+
+	private async global::System.Threading.Tasks.ValueTask TriggerCore<T>(global::System.Threading.CancellationToken token)
+		where T : global::Immediate.Jobs.Shared.IRecurringJobTrigger
+	{
+		await using var scope = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.CreateAsyncScope(_serviceProvider);
+
+		var scheduler = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetService<T>(scope.ServiceProvider);
+
+		if (scheduler is null)
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{typeof(T).Name}' was not registered.");
+
+		await scheduler.TriggerNowAsync(token).ConfigureAwait(false);
+	}
+
+	public async global::System.Threading.Tasks.ValueTask TriggerNowAsync(string name, global::System.Threading.CancellationToken cancellationToken = default)
+	{
+		if (!_jobsByName.TryGetValue(name, out var job))
+			throw new global::Immediate.Jobs.Shared.ImmediateJobException($"Recurring job '{name}' was not found.");
+
+		await job(cancellationToken).ConfigureAwait(false);
 	}
 }

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.CollectionPayloadsAndTypesWithoutPublicConstructorsGenerateValidMetadata#IJ..CollectionJob.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.CollectionPayloadsAndTypesWithoutPublicConstructorsGenerateValidMetadata#IJ..CollectionJob.g.verified.cs
@@ -37,8 +37,9 @@ partial class CollectionJob
 		}
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = "collection",
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -391,16 +392,25 @@ partial class CollectionJob
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				CollectionJob.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>(CollectionJob.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(CollectionJob.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof(CollectionJob.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<CollectionJob.Scheduler>(services);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Scoped<
+				global::Immediate.Jobs.Shared.IJobScheduler<global::CollectionJob.Payload>,
+				CollectionJob.Scheduler
+			>(global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<CollectionJob.Scheduler>)
+		);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<CollectionJob.Invoker>(services);
 
 
 		return services;

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.ContextExtractorsGenerateOrderedCaptureRestoreMetadataAndScopedRegistrations#IJ..ContextualJob.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.ContextExtractorsGenerateOrderedCaptureRestoreMetadataAndScopedRegistrations#IJ..ContextualJob.g.verified.cs
@@ -65,21 +65,21 @@ partial class ContextualJob
 			if (execution.Record.Context is { } envelope)
 			{
 				var contextSlices = global::Immediate.Jobs.Shared.JobContextEnvelope.Read(envelope);
-				
-								var contextExtractor0 = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<global::CorrelationExtractor>(scopedServices);
-								if (contextSlices.Remove(contextExtractor0.Key, out var serializedContext0))
-								{
-									var context0 = serializer.Deserialize(serializedContext0, static options => new PayloadJsonContext(options).Context0);
-									contextExtractor0.Restore(context0);
-								}
-								
-								var contextExtractor1 = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<global::UsageContextExtractor>(scopedServices);
-								if (contextSlices.Remove(contextExtractor1.Key, out var serializedContext1))
-								{
-									var context1 = serializer.Deserialize(serializedContext1, static options => new PayloadJsonContext(options).Context1);
-									contextExtractor1.Restore(context1);
-								}
-								
+
+				var contextExtractor0 = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<global::CorrelationExtractor>(scopedServices);
+				if (contextSlices.Remove(contextExtractor0.Key, out var serializedContext0))
+				{
+					var context0 = serializer.Deserialize(serializedContext0, static options => new PayloadJsonContext(options).Context0);
+					contextExtractor0.Restore(context0);
+				}
+
+				var contextExtractor1 = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<global::UsageContextExtractor>(scopedServices);
+				if (contextSlices.Remove(contextExtractor1.Key, out var serializedContext1))
+				{
+					var context1 = serializer.Deserialize(serializedContext1, static options => new PayloadJsonContext(options).Context1);
+					contextExtractor1.Restore(context1);
+				}
+
 				global::Immediate.Jobs.Shared.JobContextEnvelope.LogOrphanedSlices(scopedServices, execution.Record, contextSlices.Keys);
 			}
 
@@ -110,8 +110,9 @@ partial class ContextualJob
 			where TRequest : global::Immediate.Jobs.Shared.IJobRequest => request.JobDetails = details;
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = "contextual",
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -299,19 +300,28 @@ partial class ContextualJob
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				ContextualJob.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>(ContextualJob.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(ContextualJob.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof(ContextualJob.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<ContextualJob.Scheduler>(services);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(global::CorrelationExtractor));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(global::UsageContextExtractor));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Scoped<
+				global::Immediate.Jobs.Shared.IJobScheduler<global::ContextualJob.Payload>,
+				ContextualJob.Scheduler
+			>(global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<ContextualJob.Scheduler>)
+		);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<ContextualJob.Invoker>(services);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<global::CorrelationExtractor>(services);
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<global::UsageContextExtractor>(services);
 
 		return services;
 	}

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.CronJobGeneratesPayloadlessRecurringScheduler#IJ..CleanupSessionsJob.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.CronJobGeneratesPayloadlessRecurringScheduler#IJ..CleanupSessionsJob.g.verified.cs
@@ -61,8 +61,9 @@ partial class CleanupSessionsJob
 			where TRequest : global::Immediate.Jobs.Shared.IJobRequest => request.JobDetails = details;
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = "cleanup-sessions",
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -124,16 +125,17 @@ partial class CleanupSessionsJob
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				CleanupSessionsJob.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>(CleanupSessionsJob.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(CleanupSessionsJob.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof(CleanupSessionsJob.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<CleanupSessionsJob.Scheduler>(services);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<CleanupSessionsJob.Invoker>(services);
 
 
 		return services;

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.ExplicitJobDetailsOnValueTypeUsesConstrainedByReferenceAssignment#IJ..StructJob.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.ExplicitJobDetailsOnValueTypeUsesConstrainedByReferenceAssignment#IJ..StructJob.g.verified.cs
@@ -57,8 +57,9 @@ partial class StructJob
 			where TRequest : global::Immediate.Jobs.Shared.IJobRequest => request.JobDetails = details;
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = "struct",
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -143,16 +144,25 @@ partial class StructJob
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				StructJob.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>(StructJob.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(StructJob.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof(StructJob.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<StructJob.Scheduler>(services);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Scoped<
+				global::Immediate.Jobs.Shared.IJobScheduler<global::StructPayload>,
+				StructJob.Scheduler
+			>(global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<StructJob.Scheduler>)
+		);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<StructJob.Invoker>(services);
 
 
 		return services;

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.InvokerDelegatesExecutionToImmediateHandlersPipeline#IJ..WorkJob.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.InvokerDelegatesExecutionToImmediateHandlersPipeline#IJ..WorkJob.g.verified.cs
@@ -57,8 +57,9 @@ partial class WorkJob
 			where TRequest : global::Immediate.Jobs.Shared.IJobRequest => request.JobDetails = details;
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = "work",
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -143,16 +144,25 @@ partial class WorkJob
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				WorkJob.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>(WorkJob.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(WorkJob.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof(WorkJob.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<WorkJob.Scheduler>(services);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Scoped<
+				global::Immediate.Jobs.Shared.IJobScheduler<global::WorkJob.Payload>,
+				WorkJob.Scheduler
+			>(global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<WorkJob.Scheduler>)
+		);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<WorkJob.Invoker>(services);
 
 
 		return services;

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.JobWithoutContextDoesNotEmitCaptureOrRestoreCode#IJ..PlainJob.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.JobWithoutContextDoesNotEmitCaptureOrRestoreCode#IJ..PlainJob.g.verified.cs
@@ -67,8 +67,9 @@ partial class PlainJob
 			where TRequest : global::Immediate.Jobs.Shared.IJobRequest => request.JobDetails = details;
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = "plain",
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -129,16 +130,17 @@ partial class PlainJob
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				PlainJob.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>(PlainJob.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(PlainJob.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof(PlainJob.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<PlainJob.Scheduler>(services);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<PlainJob.Invoker>(services);
 
 
 		return services;

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.NodaTimeContextUsesConfiguredGeneratedMetadata#IJ..ClockJob.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.NodaTimeContextUsesConfiguredGeneratedMetadata#IJ..ClockJob.g.verified.cs
@@ -62,14 +62,14 @@ partial class ClockJob
 			if (execution.Record.Context is { } envelope)
 			{
 				var contextSlices = global::Immediate.Jobs.Shared.JobContextEnvelope.Read(envelope);
-				
-								var contextExtractor0 = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<global::ClockExtractor>(scopedServices);
-								if (contextSlices.Remove(contextExtractor0.Key, out var serializedContext0))
-								{
-									var context0 = serializer.Deserialize(serializedContext0, static options => new PayloadJsonContext(options).Context0);
-									contextExtractor0.Restore(context0);
-								}
-								
+
+				var contextExtractor0 = global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<global::ClockExtractor>(scopedServices);
+				if (contextSlices.Remove(contextExtractor0.Key, out var serializedContext0))
+				{
+					var context0 = serializer.Deserialize(serializedContext0, static options => new PayloadJsonContext(options).Context0);
+					contextExtractor0.Restore(context0);
+				}
+
 				global::Immediate.Jobs.Shared.JobContextEnvelope.LogOrphanedSlices(scopedServices, execution.Record, contextSlices.Keys);
 			}
 
@@ -100,8 +100,9 @@ partial class ClockJob
 			where TRequest : global::Immediate.Jobs.Shared.IJobRequest => request.JobDetails = details;
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = "clock",
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -208,18 +209,19 @@ partial class ClockJob
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				ClockJob.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>(ClockJob.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(ClockJob.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof(ClockJob.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<ClockJob.Scheduler>(services);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(global::ClockExtractor));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<ClockJob.Invoker>(services);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<global::ClockExtractor>(services);
 
 		return services;
 	}

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.NullableValueTypeMembersGenerateValidMetadata#IJ..NullablePayloadJob.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.NullableValueTypeMembersGenerateValidMetadata#IJ..NullablePayloadJob.g.verified.cs
@@ -37,8 +37,9 @@ partial class NullablePayloadJob
 		}
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = "nullable-payload",
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -154,16 +155,25 @@ partial class NullablePayloadJob
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				NullablePayloadJob.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>(NullablePayloadJob.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(NullablePayloadJob.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof(NullablePayloadJob.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<NullablePayloadJob.Scheduler>(services);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Scoped<
+				global::Immediate.Jobs.Shared.IJobScheduler<global::NullablePayloadJob.Payload>,
+				NullablePayloadJob.Scheduler
+			>(global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<NullablePayloadJob.Scheduler>)
+		);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<NullablePayloadJob.Invoker>(services);
 
 
 		return services;

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.PayloadJobGeneratesTypedSchedulerDirectInvokerAndRegistrations#IJ.Example.SendEmailJob.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.PayloadJobGeneratesTypedSchedulerDirectInvokerAndRegistrations#IJ.Example.SendEmailJob.g.verified.cs
@@ -60,8 +60,9 @@ partial class SendEmailJob
 			where TRequest : global::Immediate.Jobs.Shared.IJobRequest => request.JobDetails = details;
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = "send-email",
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -168,16 +169,25 @@ partial class SendEmailJob
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				SendEmailJob.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>(SendEmailJob.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(SendEmailJob.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof(SendEmailJob.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<SendEmailJob.Scheduler>(services);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Scoped<
+				global::Immediate.Jobs.Shared.IJobScheduler<global::Example.SendEmailJob.Payload>,
+				SendEmailJob.Scheduler
+			>(global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<SendEmailJob.Scheduler>)
+		);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<SendEmailJob.Invoker>(services);
 
 
 		return services;

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.PayloadlessJobWithoutCronGeneratesDynamicRecurringScheduler#IJ..TenantCleanupJob.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.PayloadlessJobWithoutCronGeneratesDynamicRecurringScheduler#IJ..TenantCleanupJob.g.verified.cs
@@ -67,8 +67,9 @@ partial class TenantCleanupJob
 			where TRequest : global::Immediate.Jobs.Shared.IJobRequest => request.JobDetails = details;
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = "tenant-cleanup",
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -129,16 +130,17 @@ partial class TenantCleanupJob
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				TenantCleanupJob.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>(TenantCleanupJob.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(TenantCleanupJob.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof(TenantCleanupJob.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<TenantCleanupJob.Scheduler>(services);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<TenantCleanupJob.Invoker>(services);
 
 
 		return services;

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.PlainRequestGeneratesJobWithoutJobDetailsAssignment#IJ..PlainRequestJob.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.PlainRequestGeneratesJobWithoutJobDetailsAssignment#IJ..PlainRequestJob.g.verified.cs
@@ -37,8 +37,9 @@ partial class PlainRequestJob
 		}
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = "plain-request",
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -123,16 +124,25 @@ partial class PlainRequestJob
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				PlainRequestJob.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>(PlainRequestJob.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(PlainRequestJob.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof(PlainRequestJob.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<PlainRequestJob.Scheduler>(services);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Scoped<
+				global::Immediate.Jobs.Shared.IJobScheduler<global::PlainRequestJob.Payload>,
+				PlainRequestJob.Scheduler
+			>(global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<PlainRequestJob.Scheduler>)
+		);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<PlainRequestJob.Invoker>(services);
 
 
 		return services;

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.RequiredPropertyBackedPayloadGeneratesCompilableMetadata_setterKeyword=init#IJ..PropertyBackedPayloadJob.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.RequiredPropertyBackedPayloadGeneratesCompilableMetadata_setterKeyword=init#IJ..PropertyBackedPayloadJob.g.verified.cs
@@ -37,8 +37,9 @@ partial class PropertyBackedPayloadJob
 		}
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = "property-backed-payload",
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -126,16 +127,25 @@ partial class PropertyBackedPayloadJob
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				PropertyBackedPayloadJob.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>(PropertyBackedPayloadJob.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(PropertyBackedPayloadJob.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof(PropertyBackedPayloadJob.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<PropertyBackedPayloadJob.Scheduler>(services);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Scoped<
+				global::Immediate.Jobs.Shared.IJobScheduler<global::PropertyBackedPayloadJob.Payload>,
+				PropertyBackedPayloadJob.Scheduler
+			>(global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<PropertyBackedPayloadJob.Scheduler>)
+		);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<PropertyBackedPayloadJob.Invoker>(services);
 
 
 		return services;

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.RequiredPropertyBackedPayloadGeneratesCompilableMetadata_setterKeyword=set#IJ..PropertyBackedPayloadJob.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/ImmediateJobsGeneratorTests.RequiredPropertyBackedPayloadGeneratesCompilableMetadata_setterKeyword=set#IJ..PropertyBackedPayloadJob.g.verified.cs
@@ -37,8 +37,9 @@ partial class PropertyBackedPayloadJob
 		}
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = "property-backed-payload",
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -126,16 +127,25 @@ partial class PropertyBackedPayloadJob
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				PropertyBackedPayloadJob.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>(PropertyBackedPayloadJob.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(PropertyBackedPayloadJob.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof(PropertyBackedPayloadJob.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<PropertyBackedPayloadJob.Scheduler>(services);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Scoped<
+				global::Immediate.Jobs.Shared.IJobScheduler<global::PropertyBackedPayloadJob.Payload>,
+				PropertyBackedPayloadJob.Scheduler
+			>(global::Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<PropertyBackedPayloadJob.Scheduler>)
+		);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<PropertyBackedPayloadJob.Invoker>(services);
 
 
 		return services;

--- a/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/UnnameableJobsTests.ExplicitNameShouldRescueAnUnderivableClassName#IJ.Dummy.Job.g.verified.cs
+++ b/tests/Immediate.Jobs.Tests/GeneratorTests/Snapshots/UnnameableJobsTests.ExplicitNameShouldRescueAnUnderivableClassName#IJ.Dummy.Job.g.verified.cs
@@ -70,8 +70,9 @@ partial class Job
 			where TRequest : global::Immediate.Jobs.Shared.IJobRequest => request.JobDetails = details;
 	}
 
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	internal static global::Immediate.Jobs.Shared.JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
+	internal sealed record JobDefinition : global::Immediate.Jobs.Shared.JobDefinition;
+
+	internal static JobDefinition CreateJobDefinition(global::System.IServiceProvider services) => new()
 	{
 		Name = "the-job",
 		Queue = new global::Immediate.Jobs.Shared.JobQueueDefinition
@@ -132,16 +133,17 @@ partial class Job
 		global::Microsoft.Extensions.DependencyInjection.IServiceCollection services
 	)
 	{
-		services.Add(
-			new global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor(
-				typeof(global::Immediate.Jobs.Shared.JobDefinition),
-				Job.CreateJobDefinition,
-				global::Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton
-			)
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(
+			services,
+			global::Microsoft.Extensions.DependencyInjection.ServiceDescriptor.Singleton<
+				global::Immediate.Jobs.Shared.JobDefinition,
+				JobDefinition
+			>(Job.CreateJobDefinition)
 		);
 
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped(services, typeof(Job.Scheduler));
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton(services, typeof(Job.Invoker));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddScoped<Job.Scheduler>(services);
+
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddSingleton<Job.Invoker>(services);
 
 
 		return services;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added named recurring-job triggering through the `RecurringJobs` service.
  - Recurring jobs can be triggered asynchronously by name, with clear errors for unknown or unavailable jobs.
  - Payloadless jobs now appear in generated job metadata.
  - Job and queue names are publicly accessible for improved scheduler visibility.

- **Bug Fixes**
  - Job and tag group registration now consistently includes all applicable jobs.
  - Improved generated service registration reliability across supported frameworks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->