### PR TITLE
Deduplicate hosted scheduler registration

### DIFF
--- a/src/Immediate.Jobs.Shared/ServiceCollectionExtensions.cs
+++ b/src/Immediate.Jobs.Shared/ServiceCollectionExtensions.cs
@@ -58,7 +58,11 @@ public static class ImmediateJobsRuntimeServiceCollectionExtensions
 		_ = services.AddSingleton(JobQueueDefinition.Default);
 		services.TryAddSingleton<JobSchedulerState>();
 		services.TryAddSingleton<JobSchedulerService>();
-		services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, JobSchedulerHostedService>());
+
+		services.TryAddEnumerable(
+			ServiceDescriptor.Singleton<IHostedService, JobSchedulerService>(sp => sp.GetRequiredService<JobSchedulerService>())
+		);
+
 		return new(services);
 	}
 
@@ -95,12 +99,4 @@ public static class ImmediateJobsRuntimeServiceCollectionExtensions
 		_ = builder.Services.AddHealthChecks().AddCheck<ImmediateJobsHealthCheck>(name, failureStatus, tags ?? []);
 		return builder;
 	}
-}
-
-[SuppressMessage("Performance", "CA1812", Justification = "Activated by dependency injection.")]
-internal sealed class JobSchedulerHostedService(JobSchedulerService scheduler) : IHostedService
-{
-	public Task StartAsync(CancellationToken cancellationToken) => scheduler.StartAsync(cancellationToken);
-
-	public Task StopAsync(CancellationToken cancellationToken) => scheduler.StopAsync(cancellationToken);
 }

--- a/src/Immediate.Jobs.Shared/ServiceCollectionExtensions.cs
+++ b/src/Immediate.Jobs.Shared/ServiceCollectionExtensions.cs
@@ -58,9 +58,7 @@ public static class ImmediateJobsRuntimeServiceCollectionExtensions
 		_ = services.AddSingleton(JobQueueDefinition.Default);
 		services.TryAddSingleton<JobSchedulerState>();
 		services.TryAddSingleton<JobSchedulerService>();
-		_ = services.AddSingleton<IHostedService>(
-			static sp => sp.GetRequiredService<JobSchedulerService>()
-		);
+		services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, JobSchedulerHostedService>());
 		return new(services);
 	}
 
@@ -97,4 +95,12 @@ public static class ImmediateJobsRuntimeServiceCollectionExtensions
 		_ = builder.Services.AddHealthChecks().AddCheck<ImmediateJobsHealthCheck>(name, failureStatus, tags ?? []);
 		return builder;
 	}
+}
+
+[SuppressMessage("Performance", "CA1812", Justification = "Activated by dependency injection.")]
+internal sealed class JobSchedulerHostedService(JobSchedulerService scheduler) : IHostedService
+{
+	public Task StartAsync(CancellationToken cancellationToken) => scheduler.StartAsync(cancellationToken);
+
+	public Task StopAsync(CancellationToken cancellationToken) => scheduler.StopAsync(cancellationToken);
 }

--- a/tests/Immediate.Jobs.FunctionalTests/QueueSchedulerTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/QueueSchedulerTests.cs
@@ -8,6 +8,19 @@ namespace Immediate.Jobs.FunctionalTests;
 public sealed class QueueSchedulerTests
 {
 	[Fact]
+	public async Task RepeatedRuntimeRegistrationAddsOneHostedScheduler()
+	{
+		var services = new ServiceCollection();
+		_ = services.AddLogging();
+		_ = services.AddImmediateJobsCore();
+		_ = services.AddImmediateJobsCore();
+
+		await using var provider = services.BuildServiceProvider();
+
+		_ = Assert.Single(provider.GetServices<IHostedService>());
+	}
+
+	[Fact]
 	public async Task SchedulerAppliesQueueAndJobLimitsBeforeDispatch()
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;

--- a/tests/Immediate.Jobs.FunctionalTests/QueueSchedulerTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/QueueSchedulerTests.cs
@@ -19,8 +19,11 @@ public sealed class QueueSchedulerTests
 		await using var provider = services.BuildServiceProvider();
 		var hostedServices = provider.GetServices<IHostedService>().ToArray();
 
-		Assert.Equal(2, hostedServices.Length);
-		_ = Assert.Single(hostedServices.OfType<OtherHostedService>());
+		Assert.Collection(
+			hostedServices,
+			sd => Assert.IsType<OtherHostedService>(sd),
+			sd => Assert.IsType<JobSchedulerService>(sd)
+		);
 	}
 
 	[Fact]

--- a/tests/Immediate.Jobs.FunctionalTests/QueueSchedulerTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/QueueSchedulerTests.cs
@@ -8,16 +8,19 @@ namespace Immediate.Jobs.FunctionalTests;
 public sealed class QueueSchedulerTests
 {
 	[Fact]
-	public async Task RepeatedRuntimeRegistrationAddsOneHostedScheduler()
+	public async Task RepeatedRuntimeRegistrationPreservesOtherHostedServicesAndAddsOneScheduler()
 	{
 		var services = new ServiceCollection();
 		_ = services.AddLogging();
+		_ = services.AddHostedService<OtherHostedService>();
 		_ = services.AddImmediateJobsCore();
 		_ = services.AddImmediateJobsCore();
 
 		await using var provider = services.BuildServiceProvider();
+		var hostedServices = provider.GetServices<IHostedService>().ToArray();
 
-		_ = Assert.Single(provider.GetServices<IHostedService>());
+		Assert.Equal(2, hostedServices.Length);
+		_ = Assert.Single(hostedServices.OfType<OtherHostedService>());
 	}
 
 	[Fact]
@@ -120,6 +123,13 @@ public sealed class QueueSchedulerTests
 				_ = _activeByJob.AddOrUpdate(record.JobName, 0, static (_, count) => count - 1);
 			}
 		}
+	}
+
+	private sealed class OtherHostedService : IHostedService
+	{
+		public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+		public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 	}
 }
 #pragma warning restore CS1591


### PR DESCRIPTION
Repeated AddImmediateJobsCore calls registered the same singleton JobSchedulerService as IHostedService multiple times. The host therefore started multiple scheduler loops sharing one worker identity, causing duplicate server heartbeat and execution writes.\n\nThis registers a deduplicated hosted-service adapter while preserving the concrete scheduler singleton and adds regression coverage for repeated runtime registration.\n\nValidation:\n- multi-target functional test build: net8.0, net9.0, net10.0, net11.0\n- 780 functional tests passed across all four target frameworks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate job scheduler services when core job services are registered multiple times.
  * Preserved other hosted services during repeated registration.
  * Improved job scheduler service registration for reliable application startup and shutdown.

* **Tests**
  * Added coverage confirming repeated core registration preserves existing hosted services and creates only one scheduler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->