### PR TITLE
Support mixed job and batch continuation parents

### DIFF
--- a/docs/batches-and-continuations.md
+++ b/docs/batches-and-continuations.md
@@ -706,6 +706,12 @@ for a job with a `Payload` request):
     ValueTask<JobHandle> ScheduleAfterAsync(ReadOnlySpan<JobHandle> parents, Payload payload,   // fan-in
         ContinuationTrigger on = ContinuationTrigger.Success,
         TimeSpan? delay = null, CancellationToken ct = default);
+    ValueTask<JobHandle> ScheduleAfterAsync(ReadOnlySpan<BatchHandle> parentBatches, Payload payload,
+        ContinuationTrigger on = ContinuationTrigger.Success,
+        TimeSpan? delay = null, CancellationToken ct = default);
+    ValueTask<JobHandle> ScheduleAfterAsync(ReadOnlySpan<IContinuationHandle> parents, Payload payload, // mixed fan-in
+        ContinuationTrigger on = ContinuationTrigger.Success,
+        TimeSpan? delay = null, CancellationToken ct = default);
     ValueTask<JobHandle> ScheduleAfterAsync(BatchHandle parentBatch, Payload payload,
         ContinuationTrigger on = ContinuationTrigger.Success,
         TimeSpan? delay = null, CancellationToken ct = default);
@@ -735,12 +741,17 @@ public sealed class JobBatch : IAsyncDisposable
     public ValueTask<BatchHandle> CommitAsync(CancellationToken ct = default);
 }
 
-public readonly struct JobHandle          // carries the job Id (+ owning batch, if any)
+public interface IContinuationHandle
 {
     string Id { get; }
 }
 
-public sealed class BatchHandle           // carries the batch Id
+public readonly struct JobHandle : IContinuationHandle // carries the job Id (+ owning batch, if any)
+{
+    string Id { get; }
+}
+
+public sealed class BatchHandle : IContinuationHandle // carries the batch Id
 {
     string Id { get; }
 }

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,16 @@ await finalize.ScheduleAfterAsync(
 BatchHandle committed = await batch.CommitAsync(cancellationToken);
 ```
 
+Fan-in can also wait for several committed batches, or mix committed batches and standalone jobs:
+
+```csharp
+await finalize.ScheduleAfterAsync(
+	[firstBatch, secondBatch, importedJob, indexedJob],
+	new(importId),
+	cancellationToken: cancellationToken
+);
+```
+
 Cancel every non-terminal member through the same batch scheduler:
 
 ```csharp

--- a/spec.md
+++ b/spec.md
@@ -251,9 +251,10 @@ cannot double-enqueue. `RunAsync(body)` is sugar over `Begin → body → Commit
 schedules *its own* job to run after `parent`, returning a new `JobHandle` so chains compose. Passing
 several parents as a collection (`[a, b, c]`) expresses **fan-in**; calling `ScheduleAfterAsync` on the same parent twice
 expresses **fan-out**; diamonds and continuations-of-continuations follow naturally. Parents may be a
-`JobHandle`, a collection of handles, or a committed batch's `BatchHandle` (a job that runs once the
-whole batch completes). Continuations work inside or outside a batch; a standalone continuation whose
-parent is already terminal is evaluated immediately rather than waiting forever.
+`JobHandle`, a committed batch's `BatchHandle`, or a collection that mixes both handle types (a job
+that runs once every parent job and whole parent batch completes). Continuations work inside or
+outside a batch; a standalone continuation whose parent is already terminal is evaluated immediately
+rather than waiting forever.
 
 **Mid-job dynamic expansion.** A running member can expand the workflow at execution time using its
 own `JobDetails` (from `IJobRequest`) as the "I am running inside this job" token:

--- a/src/Immediate.Jobs.NodaTime/NodaTimeJobSchedulerExtensions.cs
+++ b/src/Immediate.Jobs.NodaTime/NodaTimeJobSchedulerExtensions.cs
@@ -161,6 +161,50 @@ public static class NodaTimeJobSchedulerExtensions
 		return scheduler.ScheduleAfterAsync(parents, payload, on, delay?.ToTimeSpan(), cancellationToken);
 	}
 
+	/// <summary>Schedules a payload after every supplied parent batch with an optional NodaTime delay.</summary>
+	/// <typeparam name="TPayload">The type of payload to schedule.</typeparam>
+	/// <param name="scheduler">The typed job scheduler.</param>
+	/// <param name="parents">The parent batches that control the continuation.</param>
+	/// <param name="payload">The payload to schedule.</param>
+	/// <param name="on">The parent outcomes that trigger the continuation.</param>
+	/// <param name="delay">The optional duration to wait after the continuation is triggered.</param>
+	/// <param name="cancellationToken">A token that can cancel the operation.</param>
+	/// <returns>A task whose result identifies the scheduled continuation.</returns>
+	public static ValueTask<JobHandle> ScheduleAfterAsync<TPayload>(
+		this JobScheduler<TPayload> scheduler,
+		ReadOnlySpan<BatchHandle> parents,
+		TPayload payload,
+		ContinuationTrigger on = ContinuationTrigger.Success,
+		Duration? delay = null,
+		CancellationToken cancellationToken = default
+	)
+	{
+		ArgumentNullException.ThrowIfNull(scheduler);
+		return scheduler.ScheduleAfterAsync(parents, payload, on, delay?.ToTimeSpan(), cancellationToken);
+	}
+
+	/// <summary>Schedules a payload after every supplied parent job and batch with an optional NodaTime delay.</summary>
+	/// <typeparam name="TPayload">The type of payload to schedule.</typeparam>
+	/// <param name="scheduler">The typed job scheduler.</param>
+	/// <param name="parents">The parent jobs and batches that control the continuation.</param>
+	/// <param name="payload">The payload to schedule.</param>
+	/// <param name="on">The parent outcomes that trigger the continuation.</param>
+	/// <param name="delay">The optional duration to wait after the continuation is triggered.</param>
+	/// <param name="cancellationToken">A token that can cancel the operation.</param>
+	/// <returns>A task whose result identifies the scheduled continuation.</returns>
+	public static ValueTask<JobHandle> ScheduleAfterAsync<TPayload>(
+		this JobScheduler<TPayload> scheduler,
+		ReadOnlySpan<IContinuationHandle> parents,
+		TPayload payload,
+		ContinuationTrigger on = ContinuationTrigger.Success,
+		Duration? delay = null,
+		CancellationToken cancellationToken = default
+	)
+	{
+		ArgumentNullException.ThrowIfNull(scheduler);
+		return scheduler.ScheduleAfterAsync(parents, payload, on, delay?.ToTimeSpan(), cancellationToken);
+	}
+
 	/// <summary>Schedules a payload after a whole batch with an optional NodaTime delay.</summary>
 	/// <typeparam name="TPayload">The type of payload to schedule.</typeparam>
 	/// <param name="scheduler">The typed job scheduler.</param>

--- a/src/Immediate.Jobs.Shared/JobBatchModels.cs
+++ b/src/Immediate.Jobs.Shared/JobBatchModels.cs
@@ -1,7 +1,7 @@
 namespace Immediate.Jobs.Shared;
 
 /// <summary>An opaque reference to a durable job invocation.</summary>
-public readonly struct JobHandle : IEquatable<JobHandle>
+public readonly struct JobHandle : IContinuationHandle, IEquatable<JobHandle>
 {
 	/// <summary>Creates a handle for an existing invocation identifier.</summary>
 	/// <param name="id">The opaque invocation identifier.</param>
@@ -46,7 +46,7 @@ public readonly struct JobHandle : IEquatable<JobHandle>
 }
 
 /// <summary>An opaque reference to a committed atomic batch.</summary>
-public sealed record BatchHandle
+public sealed record BatchHandle : IContinuationHandle
 {
 	/// <summary>Creates a handle for an existing batch identifier.</summary>
 	/// <param name="id">The opaque batch identifier.</param>
@@ -59,6 +59,14 @@ public sealed record BatchHandle
 	/// <summary>The opaque batch identifier.</summary>
 	/// <value>The opaque batch identifier.</value>
 	public string Id { get; }
+}
+
+/// <summary>An opaque reference that can act as a continuation parent.</summary>
+public interface IContinuationHandle
+{
+	/// <summary>The opaque job or batch identifier.</summary>
+	/// <value>The opaque job or batch identifier.</value>
+	string Id { get; }
 }
 
 /// <summary>Determines how a continuation evaluates its parents.</summary>

--- a/src/Immediate.Jobs.Shared/JobSchedulers.cs
+++ b/src/Immediate.Jobs.Shared/JobSchedulers.cs
@@ -300,6 +300,63 @@ public abstract class JobScheduler<TPayload>(
 		return ScheduleAfterCoreAsync(parents.ToArray(), payload, on, delay, cancellationToken);
 	}
 
+	/// <summary>Schedules work after every supplied parent batch.</summary>
+	/// <param name="parents">The batches that must finish before this work is released.</param>
+	/// <param name="payload">The payload for the continuation.</param>
+	/// <param name="on">The parent outcomes that release the continuation.</param>
+	/// <param name="delay">The optional delay applied when the continuation is released.</param>
+	/// <param name="cancellationToken">A token that can cancel the scheduling operation.</param>
+	/// <returns>A handle for the scheduled continuation.</returns>
+	public ValueTask<JobHandle> ScheduleAfterAsync(
+		ReadOnlySpan<BatchHandle> parents,
+		TPayload payload,
+		ContinuationTrigger on = ContinuationTrigger.Success,
+		TimeSpan? delay = null,
+		CancellationToken cancellationToken = default
+	)
+	{
+		if (delay < TimeSpan.Zero)
+			throw new ArgumentOutOfRangeException(nameof(delay), "A job delay cannot be negative.");
+		if (parents.IsEmpty)
+			throw new ArgumentException("At least one continuation parent is required.", nameof(parents));
+		var continuationParents = new IContinuationHandle[parents.Length];
+		for (var index = 0; index < parents.Length; index++)
+			continuationParents[index] = parents[index];
+		return ScheduleAfterCoreAsync(continuationParents, payload, on, delay, cancellationToken);
+	}
+
+	/// <summary>Schedules work after every supplied parent job and batch.</summary>
+	/// <param name="parents">The jobs and batches that must finish before this work is released.</param>
+	/// <param name="payload">The payload for the continuation.</param>
+	/// <param name="on">The parent outcomes that release the continuation.</param>
+	/// <param name="delay">The optional delay applied when the continuation is released.</param>
+	/// <param name="cancellationToken">A token that can cancel the scheduling operation.</param>
+	/// <returns>A handle for the scheduled continuation.</returns>
+	public ValueTask<JobHandle> ScheduleAfterAsync(
+		ReadOnlySpan<IContinuationHandle> parents,
+		TPayload payload,
+		ContinuationTrigger on = ContinuationTrigger.Success,
+		TimeSpan? delay = null,
+		CancellationToken cancellationToken = default
+	)
+	{
+		if (delay < TimeSpan.Zero)
+			throw new ArgumentOutOfRangeException(nameof(delay), "A job delay cannot be negative.");
+		if (parents.IsEmpty)
+			throw new ArgumentException("At least one continuation parent is required.", nameof(parents));
+
+		var continuationParents = parents.ToArray();
+		var jobs = new JobHandle[continuationParents.Length];
+		for (var index = 0; index < continuationParents.Length; index++)
+		{
+			if (continuationParents[index] is not JobHandle job)
+				return ScheduleAfterCoreAsync(continuationParents, payload, on, delay, cancellationToken);
+			jobs[index] = job;
+		}
+
+		return ScheduleAfterCoreAsync(jobs, payload, on, delay, cancellationToken);
+	}
+
 	/// <summary>Schedules work after a whole batch reaches a terminal state.</summary>
 	/// <param name="parent">The batch that must finish before this work is released.</param>
 	/// <param name="payload">The payload for the continuation.</param>
@@ -307,7 +364,7 @@ public abstract class JobScheduler<TPayload>(
 	/// <param name="delay">The optional delay applied when the continuation is released.</param>
 	/// <param name="cancellationToken">A token that can cancel the scheduling operation.</param>
 	/// <returns>A handle for the scheduled continuation.</returns>
-	public async ValueTask<JobHandle> ScheduleAfterAsync(
+	public ValueTask<JobHandle> ScheduleAfterAsync(
 		BatchHandle parent,
 		TPayload payload,
 		ContinuationTrigger on = ContinuationTrigger.Success,
@@ -316,18 +373,7 @@ public abstract class JobScheduler<TPayload>(
 	)
 	{
 		ArgumentNullException.ThrowIfNull(parent);
-		if (delay < TimeSpan.Zero)
-			throw new ArgumentOutOfRangeException(nameof(delay), "A job delay cannot be negative.");
-		var graphStorage = JobStorageCapabilityGuards.RequireGraph(Storage);
-		var record = CreateRecord(payload, TimeProvider.GetUtcNow() + (delay ?? TimeSpan.Zero));
-		var waiting = record with { State = JobState.AwaitingContinuation, RemainingDependencies = 1 };
-		await graphStorage.EnqueueContinuationAsync(
-			waiting,
-			[new() { ChildJobId = record.Id, ParentBatchId = parent.Id, Trigger = on }],
-			cancellationToken
-		).ConfigureAwait(false);
-		JobTelemetry.Enqueued(JobName, QueueName);
-		return new(record.Id);
+		return ScheduleAfterAsync([parent], payload, on, delay, cancellationToken);
 	}
 
 	/// <summary>Buffers work relative to the running job and persists it only if the attempt succeeds.</summary>
@@ -419,6 +465,60 @@ public abstract class JobScheduler<TPayload>(
 		await graphStorage.EnqueueContinuationAsync(waiting, edges, cancellationToken).ConfigureAwait(false);
 		JobTelemetry.Enqueued(JobName, QueueName);
 		return new(record.Id);
+	}
+
+	private async ValueTask<JobHandle> ScheduleAfterCoreAsync(
+		IContinuationHandle[] parents,
+		TPayload payload,
+		ContinuationTrigger on,
+		TimeSpan? delay,
+		CancellationToken cancellationToken
+	)
+	{
+		var graphStorage = JobStorageCapabilityGuards.RequireGraph(Storage);
+		var record = CreateRecord(payload, TimeProvider.GetUtcNow() + (delay ?? TimeSpan.Zero));
+		var edges = ValidateContinuationParents(parents, record.Id, on);
+		var waiting = record with { State = JobState.AwaitingContinuation, RemainingDependencies = edges.Length };
+		await graphStorage.EnqueueContinuationAsync(waiting, edges, cancellationToken).ConfigureAwait(false);
+		JobTelemetry.Enqueued(JobName, QueueName);
+		return new(record.Id);
+	}
+
+	private static JobContinuationEdge[] ValidateContinuationParents(
+		IContinuationHandle[] parents,
+		string childJobId,
+		ContinuationTrigger on
+	)
+	{
+		var jobIds = new HashSet<string>(StringComparer.Ordinal);
+		var batchIds = new HashSet<string>(StringComparer.Ordinal);
+		var edges = new JobContinuationEdge[parents.Length];
+		for (var index = 0; index < parents.Length; index++)
+		{
+			switch (parents[index])
+			{
+				case BatchHandle batch:
+					if (!batchIds.Add(batch.Id))
+						throw new ImmediateJobException($"Duplicate continuation parent batch '{batch.Id}'.");
+					edges[index] = new() { ChildJobId = childJobId, ParentBatchId = batch.Id, Trigger = on };
+					break;
+				case JobHandle job:
+					if (string.IsNullOrWhiteSpace(job.Id))
+						throw new ImmediateJobException("Continuation parent handles must have a non-empty identifier.");
+					if (job.Batch is not null)
+						throw new ImmediateJobException("Jobs from an open batch cannot be mixed with batch continuation parents.");
+					if (!jobIds.Add(job.Id))
+						throw new ImmediateJobException($"Duplicate continuation parent job '{job.Id}'.");
+					edges[index] = new() { ChildJobId = childJobId, ParentJobId = job.Id, Trigger = on };
+					break;
+				case null:
+					throw new ImmediateJobException("Continuation parent handles must not be null.");
+				default:
+					throw new ImmediateJobException($"Unsupported continuation parent handle type '{parents[index].GetType()}'.");
+			}
+		}
+
+		return edges;
 	}
 
 	private static HashSet<string> ValidateContinuationParents(JobHandle[] parents)

--- a/tests/Immediate.Jobs.FunctionalTests/BatchesAndContinuationsTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/BatchesAndContinuationsTests.cs
@@ -371,6 +371,49 @@ public sealed class BatchesAndContinuationsTests
 	}
 
 	[Fact]
+	public async Task ContinuationCanWaitForMultipleBatchesAndJobs()
+	{
+		var cancellationToken = TestContext.Current.CancellationToken;
+		var state = new BatchWorkflowState();
+		await using var harness = CreateHarness(state);
+		await using var scope = harness.Services.CreateAsyncScope();
+		var batches = scope.ServiceProvider.GetRequiredService<IJobBatchScheduler>();
+		var scheduler = scope.ServiceProvider.GetRequiredService<BatchWorkflowJob.Scheduler>();
+
+		await using var firstBatch = batches.Begin();
+		_ = scheduler.AddToBatch(firstBatch, new("first-batch"));
+		var firstBatchHandle = await firstBatch.CommitAsync(cancellationToken);
+		await using var secondBatch = batches.Begin();
+		_ = scheduler.AddToBatch(secondBatch, new("second-batch"));
+		var secondBatchHandle = await secondBatch.CommitAsync(cancellationToken);
+		var firstJob = await scheduler.EnqueueAsync(new("first-job"), cancellationToken);
+		var secondJob = await scheduler.EnqueueAsync(new("second-job"), cancellationToken);
+
+		var continuation = await scheduler.ScheduleAfterAsync(
+			[firstBatchHandle, secondBatchHandle, firstJob, secondJob],
+			new("continuation"),
+			cancellationToken: cancellationToken
+		);
+
+		var waiting = await harness.GetJobAsync(continuation, cancellationToken);
+		Assert.Equal(JobState.AwaitingContinuation, waiting.State);
+		Assert.Equal(4, waiting.RemainingDependencies);
+		var graphStorage = Assert.IsAssignableFrom<IJobGraphStorage>(harness.Storage);
+		var edges = await graphStorage.GetIncomingEdgesAsync([continuation.Id], cancellationToken);
+		Assert.Equal(4, edges.Count);
+		Assert.Equal(2, edges.Count(static edge => edge.ParentJobId is not null));
+		Assert.Equal(2, edges.Count(static edge => edge.ParentBatchId is not null));
+
+		await harness.DrainAsync(cancellationToken);
+
+		Assert.Equal(JobState.Succeeded, (await harness.GetJobAsync(continuation, cancellationToken)).State);
+		AssertBefore(state.Events, "first-batch", "continuation");
+		AssertBefore(state.Events, "second-batch", "continuation");
+		AssertBefore(state.Events, "first-job", "continuation");
+		AssertBefore(state.Events, "second-job", "continuation");
+	}
+
+	[Fact]
 	public async Task StandaloneContinuationEvaluatesAlreadyTerminalParentImmediately()
 	{
 		var cancellationToken = TestContext.Current.CancellationToken;


### PR DESCRIPTION
## Summary

- add a shared IContinuationHandle contract implemented by JobHandle and BatchHandle
- support fan-in across multiple batches and heterogeneous job/batch parent collections
- add matching NodaTime overloads, documentation, and functional coverage

## Verification

- dotnet build Immediate.Jobs.slnx --no-restore -v minimal
- dotnet test tests/Immediate.Jobs.FunctionalTests/Immediate.Jobs.FunctionalTests.csproj -f net10.0 --no-build -v quiet (197 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Schedule continuations after multiple batches.
  - Combine standalone jobs and batches as continuation dependencies.
  - Continuations now wait until all specified parent jobs and batches complete.
  - Added support for NodaTime duration-based scheduling.

- **Documentation**
  - Added examples demonstrating fan-in scheduling across batches and jobs.

- **Tests**
  - Added coverage confirming mixed job and batch dependencies execute only after all parents succeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->