### PR TITLE
Internalize storage providers

### DIFF
--- a/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
+++ b/src/Immediate.Jobs.EntityFrameworkCore/EntityFrameworkCoreJobStorage.cs
@@ -12,7 +12,7 @@ namespace Immediate.Jobs.EntityFrameworkCore;
 /// <typeparam name="TContext">The application context containing the Immediate.Jobs model.</typeparam>
 /// <param name="contextFactory">The factory used to create application database contexts.</param>
 /// <param name="timeProvider">The clock used for storage timestamps, or <see langword="null"/> to use the system clock.</param>
-public sealed class EntityFrameworkCoreJobStorage<TContext>(
+internal sealed class EntityFrameworkCoreJobStorage<TContext>(
 	IDbContextFactory<TContext> contextFactory,
 	TimeProvider? timeProvider = null
 ) : IRecurringJobStorage, IJobGraphStorage, IJobStorageReplica

--- a/src/Immediate.Jobs.EntityFrameworkCore/Immediate.Jobs.EntityFrameworkCore.csproj
+++ b/src/Immediate.Jobs.EntityFrameworkCore/Immediate.Jobs.EntityFrameworkCore.csproj
@@ -30,5 +30,10 @@
     <ProjectReference Include="../Immediate.Jobs.Shared/Immediate.Jobs.Shared.csproj" PrivateAssets="all" />
     <ProjectReference Include="../Immediate.Jobs/Immediate.Jobs.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
+
+  <ItemGroup>
+	<InternalsVisibleTo Include="Immediate.Jobs.FunctionalTests" />
+	<InternalsVisibleTo Include="Immediate.Jobs.StorageTests" />
+  </ItemGroup>
   
 </Project>

--- a/src/Immediate.Jobs.EntityFrameworkCore/ImmediateJobsModelBuilderExtensions.cs
+++ b/src/Immediate.Jobs.EntityFrameworkCore/ImmediateJobsModelBuilderExtensions.cs
@@ -8,7 +8,7 @@ namespace Immediate.Jobs.EntityFrameworkCore;
 /// <summary>Adds the Immediate.Jobs persistence model to an application DbContext.</summary>
 public static class ImmediateJobsModelBuilderExtensions
 {
-	/// <summary>Configures the entities required by <see cref="EntityFrameworkCoreJobStorage{TContext}"/>.</summary>
+	/// <summary>Configures the entities required by the Immediate.Jobs EF Core storage provider.</summary>
 	/// <param name="modelBuilder">The model builder to configure.</param>
 	/// <param name="schema">The database schema for the Immediate.Jobs tables, or <see langword="null"/> for the provider default.</param>
 	/// <returns>The configured model builder.</returns>

--- a/src/Immediate.Jobs.LinqToDB/Immediate.Jobs.LinqToDB.csproj
+++ b/src/Immediate.Jobs.LinqToDB/Immediate.Jobs.LinqToDB.csproj
@@ -30,4 +30,8 @@
     <ProjectReference Include="../Immediate.Jobs/Immediate.Jobs.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
+  <ItemGroup>
+	<InternalsVisibleTo Include="Immediate.Jobs.StorageTests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
+++ b/src/Immediate.Jobs.LinqToDB/LinqToDBJobStorage.cs
@@ -11,7 +11,7 @@ using LinqToDB.Data;
 namespace Immediate.Jobs.LinqToDB;
 
 /// <summary>An optimistic-concurrency LinqToDB implementation of <see cref="IJobStorage"/>.</summary>
-public sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage, IJobStorageReplica
+internal sealed class LinqToDBJobStorage : IRecurringJobStorage, IJobGraphStorage, IJobStorageReplica
 {
 	private const int MaxContendedCompletionAttempts = 50;
 	private const int MaxConcurrencyAttempts = 5;

--- a/src/Immediate.Jobs.Redis/Immediate.Jobs.Redis.csproj
+++ b/src/Immediate.Jobs.Redis/Immediate.Jobs.Redis.csproj
@@ -29,4 +29,8 @@
 	<ProjectReference Include="../Immediate.Jobs/Immediate.Jobs.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
+  <ItemGroup>
+	<InternalsVisibleTo Include="Immediate.Jobs.StorageTests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Immediate.Jobs.Redis/RedisJobStorage.cs
+++ b/src/Immediate.Jobs.Redis/RedisJobStorage.cs
@@ -13,7 +13,7 @@ namespace Immediate.Jobs.Redis;
 /// Distributed Redis storage for ordinary queue jobs and recurring schedules.
 /// Batches and continuations require a graph-capable SQL provider.
 /// </summary>
-public sealed class RedisJobStorage : IRecurringJobStorage, IDisposable
+internal sealed class RedisJobStorage : IRecurringJobStorage, IDisposable
 {
 	private const int QueryWindowSize = 256;
 	private const int MaximumQueryTake = 1000;

--- a/src/Immediate.Jobs.Shared/Immediate.Jobs.Shared.csproj
+++ b/src/Immediate.Jobs.Shared/Immediate.Jobs.Shared.csproj
@@ -17,4 +17,9 @@
 	<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
+  <ItemGroup>
+	<InternalsVisibleTo Include="Immediate.Jobs.Benchmarks" />
+	<InternalsVisibleTo Include="Immediate.Jobs.FunctionalTests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Immediate.Jobs.Shared/Storage/InMemoryJobStorage.cs
+++ b/src/Immediate.Jobs.Shared/Storage/InMemoryJobStorage.cs
@@ -13,7 +13,7 @@ namespace Immediate.Jobs.Shared.Storage;
 /// <param name="timeProvider">
 /// 	The clock used for scheduling, leases, and timestamps.
 /// </param>
-public sealed class InMemoryJobStorage(TimeProvider timeProvider) :
+internal sealed class InMemoryJobStorage(TimeProvider timeProvider) :
 	IRecurringJobStorage,
 	IJobGraphStorage,
 	IJobStorageReplica

--- a/src/Immediate.Jobs.Shared/Storage/SingleServerJobStorage.cs
+++ b/src/Immediate.Jobs.Shared/Storage/SingleServerJobStorage.cs
@@ -6,7 +6,7 @@ namespace Immediate.Jobs.Shared.Storage;
 /// A single-server storage topology that executes against an authoritative in-process store while
 /// synchronously replicating changes to durable storage and restoring them when the process starts.
 /// </summary>
-public sealed class SingleServerJobStorage :
+internal sealed class SingleServerJobStorage :
 	IRecurringJobStorage,
 	IJobGraphStorage,
 	IAsyncDisposable,


### PR DESCRIPTION
## Summary

- internalize the built-in in-memory, single-server, EF Core, LinqToDB, and Redis storage implementations
- keep storage selection behind the existing public configuration APIs while preserving the public custom-storage interfaces
- grant friend access only to the provider test and benchmark assemblies
- remove the public EF Core documentation reference to its implementation type

## Verification

- `dotnet build Immediate.Jobs.slnx -v minimal`
- `dotnet test tests/Immediate.Jobs.FunctionalTests/Immediate.Jobs.FunctionalTests.csproj --no-build -v minimal` (784 passed)
- `dotnet test tests/Immediate.Jobs.StorageTests/Immediate.Jobs.StorageTests.csproj --no-build -v minimal` (202 passed)
- `dotnet test tests/Immediate.Jobs.Tests/Immediate.Jobs.Tests.csproj --no-build -v minimal` (360 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restricted direct access to built-in job storage implementations while preserving their existing behavior.
  * Updated configuration documentation to reflect the streamlined storage setup.
  * Maintained internal access for supported testing and benchmarking scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->