### PR TITLE
Implement NodaTime overloads and complete CaptureOnlyJobScheduler; update tests

### DIFF
--- a/src/Immediate.Jobs.NodaTime/NodaTimeJobSchedulerExtensions.cs
+++ b/src/Immediate.Jobs.NodaTime/NodaTimeJobSchedulerExtensions.cs
@@ -82,6 +82,167 @@ public static class NodaTimeJobSchedulerExtensions
 		return scheduler.ScheduleAsync(payload, at.ToDateTimeOffset(), groupId, cancellationToken);
 	}
 
+	/// <summary>Schedules a continuation after a NodaTime duration.</summary>
+	/// <typeparam name="TPayload">The type of payload to schedule.</typeparam>
+	/// <param name="scheduler">The typed job scheduler.</param>
+	/// <param name="payload">The continuation payload.</param>
+	/// <param name="parent">The activity that must complete before the continuation is released.</param>
+	/// <param name="delay">The delay applied when the continuation is released.</param>
+	/// <param name="on">The parent outcome that releases the continuation.</param>
+	/// <param name="cancellationToken">A token that can cancel the operation.</param>
+	/// <returns>A task whose result identifies the scheduled continuation.</returns>
+	public static ValueTask<JobHandle> ScheduleAfterAsync<TPayload>(this IJobScheduler<TPayload> scheduler, TPayload payload, ContinuationHandle parent, Duration delay, ContinuationTrigger on = ContinuationTrigger.Success, CancellationToken cancellationToken = default) =>
+		scheduler.ScheduleAfterAsync(payload, parent, delay.ToTimeSpan(), on, cancellationToken);
+
+	/// <summary>Schedules a grouped continuation after a NodaTime duration.</summary>
+	/// <typeparam name="TPayload">The type of payload to schedule.</typeparam>
+	/// <param name="scheduler">The typed job scheduler.</param>
+	/// <param name="payload">The continuation payload.</param>
+	/// <param name="parent">The activity that must complete before the continuation is released.</param>
+	/// <param name="delay">The delay applied when the continuation is released.</param>
+	/// <param name="groupId">The fair-queue group identifier.</param>
+	/// <param name="on">The parent outcome that releases the continuation.</param>
+	/// <param name="cancellationToken">A token that can cancel the operation.</param>
+	/// <returns>A task whose result identifies the scheduled continuation.</returns>
+	public static ValueTask<JobHandle> ScheduleAfterAsync<TPayload>(this IJobScheduler<TPayload> scheduler, TPayload payload, ContinuationHandle parent, Duration delay, string groupId, ContinuationTrigger on = ContinuationTrigger.Success, CancellationToken cancellationToken = default) =>
+		scheduler.ScheduleAfterAsync(payload, parent, delay.ToTimeSpan(), groupId, on, cancellationToken);
+
+	/// <summary>Schedules a fan-in continuation after a NodaTime duration.</summary>
+	/// <typeparam name="TPayload">The type of payload to schedule.</typeparam>
+	/// <param name="scheduler">The typed job scheduler.</param>
+	/// <param name="payload">The continuation payload.</param>
+	/// <param name="parents">The activities that must all complete before the continuation is released.</param>
+	/// <param name="delay">The delay applied when the continuation is released.</param>
+	/// <param name="on">The parent outcomes that release the continuation.</param>
+	/// <param name="cancellationToken">A token that can cancel the operation.</param>
+	/// <returns>A task whose result identifies the scheduled continuation.</returns>
+	public static ValueTask<JobHandle> ScheduleAfterAsync<TPayload>(this IJobScheduler<TPayload> scheduler, TPayload payload, IReadOnlyList<ContinuationHandle> parents, Duration delay, ContinuationTrigger on = ContinuationTrigger.Success, CancellationToken cancellationToken = default) =>
+		scheduler.ScheduleAfterAsync(payload, parents, delay.ToTimeSpan(), on, cancellationToken);
+
+	/// <summary>Schedules a grouped fan-in continuation after a NodaTime duration.</summary>
+	/// <typeparam name="TPayload">The type of payload to schedule.</typeparam>
+	/// <param name="scheduler">The typed job scheduler.</param>
+	/// <param name="payload">The continuation payload.</param>
+	/// <param name="parents">The activities that must all complete before the continuation is released.</param>
+	/// <param name="delay">The delay applied when the continuation is released.</param>
+	/// <param name="groupId">The fair-queue group identifier.</param>
+	/// <param name="on">The parent outcomes that release the continuation.</param>
+	/// <param name="cancellationToken">A token that can cancel the operation.</param>
+	/// <returns>A task whose result identifies the scheduled continuation.</returns>
+	public static ValueTask<JobHandle> ScheduleAfterAsync<TPayload>(this IJobScheduler<TPayload> scheduler, TPayload payload, IReadOnlyList<ContinuationHandle> parents, Duration delay, string groupId, ContinuationTrigger on = ContinuationTrigger.Success, CancellationToken cancellationToken = default) =>
+		scheduler.ScheduleAfterAsync(payload, parents, delay.ToTimeSpan(), groupId, on, cancellationToken);
+
+	/// <summary>Schedules an in-execution continuation after a NodaTime duration.</summary>
+	/// <typeparam name="TPayload">The type of payload to schedule.</typeparam>
+	/// <param name="scheduler">The typed job scheduler.</param>
+	/// <param name="payload">The continuation payload.</param>
+	/// <param name="currentJob">The currently executing job.</param>
+	/// <param name="delay">The delay before the continuation becomes due.</param>
+	/// <param name="options">The placement of the new work in the continuation graph.</param>
+	/// <returns>A handle for the scheduled continuation.</returns>
+	public static JobHandle ScheduleAfter<TPayload>(this IJobScheduler<TPayload> scheduler, TPayload payload, JobDetails currentJob, Duration delay, ContinuationOptions options = ContinuationOptions.BeforeContinuations) =>
+		scheduler.ScheduleAfter(payload, currentJob, delay.ToTimeSpan(), options);
+
+	/// <summary>Schedules a grouped in-execution continuation after a NodaTime duration.</summary>
+	/// <typeparam name="TPayload">The type of payload to schedule.</typeparam>
+	/// <param name="scheduler">The typed job scheduler.</param>
+	/// <param name="payload">The continuation payload.</param>
+	/// <param name="currentJob">The currently executing job.</param>
+	/// <param name="delay">The delay before the continuation becomes due.</param>
+	/// <param name="groupId">The fair-queue group identifier.</param>
+	/// <param name="options">The placement of the new work in the continuation graph.</param>
+	/// <returns>A handle for the scheduled continuation.</returns>
+	public static JobHandle ScheduleAfter<TPayload>(this IJobScheduler<TPayload> scheduler, TPayload payload, JobDetails currentJob, Duration delay, string groupId, ContinuationOptions options = ContinuationOptions.BeforeContinuations) =>
+		scheduler.ScheduleAfter(payload, currentJob, delay.ToTimeSpan(), groupId, options);
+
+	/// <summary>Adds delayed work to a batch using a NodaTime duration.</summary>
+	/// <typeparam name="TPayload">The type of payload to schedule.</typeparam>
+	/// <param name="scheduler">The typed job scheduler.</param>
+	/// <param name="payload">The payload to add.</param>
+	/// <param name="batch">The open batch to which the job is added.</param>
+	/// <param name="delay">The delay before the job becomes due.</param>
+	/// <returns>A handle for the buffered batch job.</returns>
+	public static BatchJobHandle Schedule<TPayload>(this IJobScheduler<TPayload> scheduler, TPayload payload, Batch batch, Duration delay) =>
+		scheduler.Schedule(payload, batch, delay.ToTimeSpan());
+
+	/// <summary>Adds grouped delayed work to a batch using a NodaTime duration.</summary>
+	/// <typeparam name="TPayload">The type of payload to schedule.</typeparam>
+	/// <param name="scheduler">The typed job scheduler.</param>
+	/// <param name="payload">The payload to add.</param>
+	/// <param name="batch">The open batch to which the job is added.</param>
+	/// <param name="delay">The delay before the job becomes due.</param>
+	/// <param name="groupId">The fair-queue group identifier.</param>
+	/// <returns>A handle for the buffered batch job.</returns>
+	public static BatchJobHandle Schedule<TPayload>(this IJobScheduler<TPayload> scheduler, TPayload payload, Batch batch, Duration delay, string groupId) =>
+		scheduler.Schedule(payload, batch, delay.ToTimeSpan(), groupId);
+
+	/// <summary>Adds work to a batch at a NodaTime instant.</summary>
+	/// <typeparam name="TPayload">The type of payload to schedule.</typeparam>
+	/// <param name="scheduler">The typed job scheduler.</param>
+	/// <param name="payload">The payload to add.</param>
+	/// <param name="batch">The open batch to which the job is added.</param>
+	/// <param name="at">The instant at which the job becomes due.</param>
+	/// <returns>A handle for the buffered batch job.</returns>
+	public static BatchJobHandle Schedule<TPayload>(this IJobScheduler<TPayload> scheduler, TPayload payload, Batch batch, Instant at) =>
+		scheduler.Schedule(payload, batch, at.ToDateTimeOffset());
+
+	/// <summary>Adds grouped work to a batch at a NodaTime instant.</summary>
+	/// <typeparam name="TPayload">The type of payload to schedule.</typeparam>
+	/// <param name="scheduler">The typed job scheduler.</param>
+	/// <param name="payload">The payload to add.</param>
+	/// <param name="batch">The open batch to which the job is added.</param>
+	/// <param name="at">The instant at which the job becomes due.</param>
+	/// <param name="groupId">The fair-queue group identifier.</param>
+	/// <returns>A handle for the buffered batch job.</returns>
+	public static BatchJobHandle Schedule<TPayload>(this IJobScheduler<TPayload> scheduler, TPayload payload, Batch batch, Instant at, string groupId) =>
+		scheduler.Schedule(payload, batch, at.ToDateTimeOffset(), groupId);
+
+	/// <summary>Adds a delayed batch continuation using a NodaTime duration.</summary>
+	/// <typeparam name="TPayload">The type of payload to schedule.</typeparam>
+	/// <param name="scheduler">The typed job scheduler.</param>
+	/// <param name="payload">The continuation payload.</param>
+	/// <param name="parent">The batch job that must complete before this work is released.</param>
+	/// <param name="delay">The delay applied when the continuation is released.</param>
+	/// <param name="on">The parent-job outcome that releases the continuation.</param>
+	/// <returns>A handle for the buffered batch continuation.</returns>
+	public static BatchJobHandle ScheduleAfter<TPayload>(this IJobScheduler<TPayload> scheduler, TPayload payload, BatchJobHandle parent, Duration delay, ContinuationTrigger on = ContinuationTrigger.Success) =>
+		scheduler.ScheduleAfter(payload, parent, delay.ToTimeSpan(), on);
+
+	/// <summary>Adds a grouped delayed batch continuation using a NodaTime duration.</summary>
+	/// <typeparam name="TPayload">The type of payload to schedule.</typeparam>
+	/// <param name="scheduler">The typed job scheduler.</param>
+	/// <param name="payload">The continuation payload.</param>
+	/// <param name="parent">The batch job that must complete before this work is released.</param>
+	/// <param name="delay">The delay applied when the continuation is released.</param>
+	/// <param name="groupId">The fair-queue group identifier.</param>
+	/// <param name="on">The parent-job outcome that releases the continuation.</param>
+	/// <returns>A handle for the buffered batch continuation.</returns>
+	public static BatchJobHandle ScheduleAfter<TPayload>(this IJobScheduler<TPayload> scheduler, TPayload payload, BatchJobHandle parent, Duration delay, string groupId, ContinuationTrigger on = ContinuationTrigger.Success) =>
+		scheduler.ScheduleAfter(payload, parent, delay.ToTimeSpan(), groupId, on);
+
+	/// <summary>Adds a delayed batch fan-in continuation using a NodaTime duration.</summary>
+	/// <typeparam name="TPayload">The type of payload to schedule.</typeparam>
+	/// <param name="scheduler">The typed job scheduler.</param>
+	/// <param name="payload">The continuation payload.</param>
+	/// <param name="parents">The batch jobs that must all complete before this work is released.</param>
+	/// <param name="delay">The delay applied when the continuation is released.</param>
+	/// <param name="on">The parent-job outcomes that release the continuation.</param>
+	/// <returns>A handle for the buffered batch continuation.</returns>
+	public static BatchJobHandle ScheduleAfter<TPayload>(this IJobScheduler<TPayload> scheduler, TPayload payload, IReadOnlyList<BatchJobHandle> parents, Duration delay, ContinuationTrigger on = ContinuationTrigger.Success) =>
+		scheduler.ScheduleAfter(payload, parents, delay.ToTimeSpan(), on);
+
+	/// <summary>Adds a grouped delayed batch fan-in continuation using a NodaTime duration.</summary>
+	/// <typeparam name="TPayload">The type of payload to schedule.</typeparam>
+	/// <param name="scheduler">The typed job scheduler.</param>
+	/// <param name="payload">The continuation payload.</param>
+	/// <param name="parents">The batch jobs that must all complete before this work is released.</param>
+	/// <param name="delay">The delay applied when the continuation is released.</param>
+	/// <param name="groupId">The fair-queue group identifier.</param>
+	/// <param name="on">The parent-job outcomes that release the continuation.</param>
+	/// <returns>A handle for the buffered batch continuation.</returns>
+	public static BatchJobHandle ScheduleAfter<TPayload>(this IJobScheduler<TPayload> scheduler, TPayload payload, IReadOnlyList<BatchJobHandle> parents, Duration delay, string groupId, ContinuationTrigger on = ContinuationTrigger.Success) =>
+		scheduler.ScheduleAfter(payload, parents, delay.ToTimeSpan(), groupId, on);
+
 	/// <summary>Adds or replaces a recurring schedule in the supplied NodaTime zone.</summary>
 	/// <param name="scheduler">The recurring-job scheduler.</param>
 	/// <param name="name">The unique recurring schedule name.</param>

--- a/src/Immediate.Jobs.Testing/CaptureOnlyJobScheduler.cs
+++ b/src/Immediate.Jobs.Testing/CaptureOnlyJobScheduler.cs
@@ -27,15 +27,15 @@ public class CaptureOnlyJobScheduler<TPayload>(TimeProvider? timeProvider = null
 
 	/// <inheritdoc />
 	public virtual ValueTask<JobHandle> EnqueueAsync(TPayload payload, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
+		CaptureAsync(payload, _timeProvider.GetUtcNow(), null, cancellationToken);
 
 	/// <inheritdoc />
 	public virtual ValueTask<JobHandle> EnqueueAsync(TPayload payload, string groupId, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
+		CaptureAsync(payload, _timeProvider.GetUtcNow(), groupId, cancellationToken);
 
 	/// <inheritdoc />
 	public virtual ValueTask<JobHandle> ScheduleAsync(TPayload payload, TimeSpan delay, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
+		CaptureDelayedAsync(payload, delay, null, cancellationToken);
 
 	/// <inheritdoc />
 	public virtual ValueTask<JobHandle> ScheduleAsync(
@@ -43,11 +43,11 @@ public class CaptureOnlyJobScheduler<TPayload>(TimeProvider? timeProvider = null
 		TimeSpan delay,
 		string groupId,
 		CancellationToken cancellationToken = default
-	) => throw new NotImplementedException();
+	) => CaptureDelayedAsync(payload, delay, groupId, cancellationToken);
 
 	/// <inheritdoc />
 	public virtual ValueTask<JobHandle> ScheduleAsync(TPayload payload, DateTimeOffset at, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
+		CaptureAtAsync(payload, at, null, cancellationToken);
 
 	/// <inheritdoc />
 	public virtual ValueTask<JobHandle> ScheduleAsync(
@@ -55,98 +55,56 @@ public class CaptureOnlyJobScheduler<TPayload>(TimeProvider? timeProvider = null
 		DateTimeOffset at,
 		string groupId,
 		CancellationToken cancellationToken = default
-	) => throw new NotImplementedException();
+	) => CaptureAtAsync(payload, at, groupId, cancellationToken);
 
 	/// <inheritdoc />
-	public virtual ValueTask<JobHandle> ScheduleAfterAsync(TPayload payload, JobHandle job, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
+	public virtual ValueTask<JobHandle> ScheduleAfterAsync(TPayload payload, ContinuationHandle parent, ContinuationTrigger on = ContinuationTrigger.Success, CancellationToken cancellationToken = default) =>
+		CaptureAsync(payload, _timeProvider.GetUtcNow(), null, cancellationToken);
 
 	/// <inheritdoc />
-	public virtual ValueTask<JobHandle> ScheduleAfterAsync(TPayload payload, JobHandle job, string groupId, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
+	public virtual ValueTask<JobHandle> ScheduleAfterAsync(TPayload payload, ContinuationHandle parent, string groupId, ContinuationTrigger on = ContinuationTrigger.Success, CancellationToken cancellationToken = default) =>
+		CaptureAsync(payload, _timeProvider.GetUtcNow(), groupId, cancellationToken);
 
 	/// <inheritdoc />
-	public virtual ValueTask<JobHandle> ScheduleAfterAsync(TPayload payload, JobHandle job, TimeSpan delay, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
-
-	/// <inheritdoc />
-	public virtual ValueTask<JobHandle> ScheduleAfterAsync(
-		TPayload payload,
-		JobHandle job,
-		TimeSpan delay,
-		string groupId,
-		CancellationToken cancellationToken = default
-	) => throw new NotImplementedException();
-
-	/// <inheritdoc />
-	public virtual ValueTask<JobHandle> ScheduleAfterAsync(TPayload payload, IReadOnlyList<JobHandle> jobs, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
-
-	/// <inheritdoc />
-	public virtual ValueTask<JobHandle> ScheduleAfterAsync(TPayload payload, IReadOnlyList<JobHandle> jobs, string groupId, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
-
-	/// <inheritdoc />
-	public virtual ValueTask<JobHandle> ScheduleAfterAsync(TPayload payload, IReadOnlyList<JobHandle> jobs, TimeSpan delay, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
+	public virtual ValueTask<JobHandle> ScheduleAfterAsync(TPayload payload, ContinuationHandle parent, TimeSpan delay, ContinuationTrigger on = ContinuationTrigger.Success, CancellationToken cancellationToken = default) =>
+		CaptureDelayedAsync(payload, delay, null, cancellationToken);
 
 	/// <inheritdoc />
 	public virtual ValueTask<JobHandle> ScheduleAfterAsync(
 		TPayload payload,
-		IReadOnlyList<JobHandle> jobs,
+		ContinuationHandle parent,
 		TimeSpan delay,
 		string groupId,
-		CancellationToken cancellationToken = default
-	) => throw new NotImplementedException();
+		ContinuationTrigger on = ContinuationTrigger.Success, CancellationToken cancellationToken = default
+	) => CaptureDelayedAsync(payload, delay, groupId, cancellationToken);
 
 	/// <inheritdoc />
-	public virtual ValueTask<JobHandle> ScheduleAfterAsync(TPayload payload, BatchHandle batch, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
+	public virtual ValueTask<JobHandle> ScheduleAfterAsync(TPayload payload, IReadOnlyList<ContinuationHandle> parents, ContinuationTrigger on = ContinuationTrigger.Success, CancellationToken cancellationToken = default) =>
+		CaptureAsync(payload, _timeProvider.GetUtcNow(), null, cancellationToken);
 
 	/// <inheritdoc />
-	public virtual ValueTask<JobHandle> ScheduleAfterAsync(TPayload payload, BatchHandle batch, string groupId, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
+	public virtual ValueTask<JobHandle> ScheduleAfterAsync(TPayload payload, IReadOnlyList<ContinuationHandle> parents, string groupId, ContinuationTrigger on = ContinuationTrigger.Success, CancellationToken cancellationToken = default) =>
+		CaptureAsync(payload, _timeProvider.GetUtcNow(), groupId, cancellationToken);
 
 	/// <inheritdoc />
-	public virtual ValueTask<JobHandle> ScheduleAfterAsync(TPayload payload, BatchHandle batch, TimeSpan delay, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
+	public virtual ValueTask<JobHandle> ScheduleAfterAsync(TPayload payload, IReadOnlyList<ContinuationHandle> parents, TimeSpan delay, ContinuationTrigger on = ContinuationTrigger.Success, CancellationToken cancellationToken = default) =>
+		CaptureDelayedAsync(payload, delay, null, cancellationToken);
 
 	/// <inheritdoc />
 	public virtual ValueTask<JobHandle> ScheduleAfterAsync(
 		TPayload payload,
-		BatchHandle batch,
+		IReadOnlyList<ContinuationHandle> parents,
 		TimeSpan delay,
 		string groupId,
-		CancellationToken cancellationToken = default
-	) => throw new NotImplementedException();
-
-	/// <inheritdoc />
-	public virtual ValueTask<JobHandle> ScheduleAfterAsync(TPayload payload, IReadOnlyList<BatchHandle> batches, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
-
-	/// <inheritdoc />
-	public virtual ValueTask<JobHandle> ScheduleAfterAsync(TPayload payload, IReadOnlyList<BatchHandle> batches, string groupId, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
-
-	/// <inheritdoc />
-	public virtual ValueTask<JobHandle> ScheduleAfterAsync(TPayload payload, IReadOnlyList<BatchHandle> batches, TimeSpan delay, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
-
-	/// <inheritdoc />
-	public virtual ValueTask<JobHandle> ScheduleAfterAsync(
-		TPayload payload,
-		IReadOnlyList<BatchHandle> batches,
-		TimeSpan delay,
-		string groupId,
-		CancellationToken cancellationToken = default
-	) => throw new NotImplementedException();
+		ContinuationTrigger on = ContinuationTrigger.Success, CancellationToken cancellationToken = default
+	) => CaptureDelayedAsync(payload, delay, groupId, cancellationToken);
 
 	/// <inheritdoc />
 	public virtual JobHandle ScheduleAfter(
 		TPayload payload,
 		JobDetails currentJob,
 		ContinuationOptions options = ContinuationOptions.BeforeContinuations
-	) => throw new NotImplementedException();
+	) => Capture(payload, _timeProvider.GetUtcNow(), null);
 
 	/// <inheritdoc />
 	public virtual JobHandle ScheduleAfter(
@@ -154,7 +112,7 @@ public class CaptureOnlyJobScheduler<TPayload>(TimeProvider? timeProvider = null
 		JobDetails currentJob,
 		string groupId,
 		ContinuationOptions options = ContinuationOptions.BeforeContinuations
-	) => throw new NotImplementedException();
+	) => Capture(payload, _timeProvider.GetUtcNow(), groupId);
 
 	/// <inheritdoc />
 	public virtual JobHandle ScheduleAfter(
@@ -162,7 +120,7 @@ public class CaptureOnlyJobScheduler<TPayload>(TimeProvider? timeProvider = null
 		JobDetails currentJob,
 		TimeSpan delay,
 		ContinuationOptions options = ContinuationOptions.BeforeContinuations
-	) => throw new NotImplementedException();
+	) => CaptureDelayed(payload, delay, null);
 
 	/// <inheritdoc />
 	public virtual JobHandle ScheduleAfter(
@@ -171,43 +129,43 @@ public class CaptureOnlyJobScheduler<TPayload>(TimeProvider? timeProvider = null
 		TimeSpan delay,
 		string groupId,
 		ContinuationOptions options = ContinuationOptions.BeforeContinuations
-	) => throw new NotImplementedException();
+	) => CaptureDelayed(payload, delay, groupId);
 
 	/// <inheritdoc />
 	public virtual BatchJobHandle Enqueue(TPayload payload, Batch batch) =>
-		throw new NotImplementedException();
+		CaptureBatch(payload, batch, _timeProvider.GetUtcNow(), null);
 
 	/// <inheritdoc />
 	public virtual BatchJobHandle Enqueue(TPayload payload, Batch batch, string groupId) =>
-		throw new NotImplementedException();
+		CaptureBatch(payload, batch, _timeProvider.GetUtcNow(), groupId);
 
 	/// <inheritdoc />
 	public virtual BatchJobHandle Schedule(TPayload payload, Batch batch, TimeSpan delay) =>
-		throw new NotImplementedException();
+		CaptureBatchDelayed(payload, batch, delay, null);
 
 	/// <inheritdoc />
 	public virtual BatchJobHandle Schedule(TPayload payload, Batch batch, TimeSpan delay, string groupId) =>
-		throw new NotImplementedException();
+		CaptureBatchDelayed(payload, batch, delay, groupId);
 
 	/// <inheritdoc />
 	public virtual BatchJobHandle Schedule(TPayload payload, Batch batch, DateTimeOffset at) =>
-		throw new NotImplementedException();
+		CaptureBatchAt(payload, batch, at, null);
 
 	/// <inheritdoc />
 	public virtual BatchJobHandle Schedule(TPayload payload, Batch batch, DateTimeOffset at, string groupId) =>
-		throw new NotImplementedException();
+		CaptureBatchAt(payload, batch, at, groupId);
 
 	/// <inheritdoc />
-	public virtual BatchJobHandle ScheduleAfter(TPayload payload, BatchJobHandle job, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
+	public virtual BatchJobHandle ScheduleAfter(TPayload payload, BatchJobHandle job, ContinuationTrigger on = ContinuationTrigger.Success) =>
+		CaptureBatch(payload, job.Batch, _timeProvider.GetUtcNow(), null);
 
 	/// <inheritdoc />
-	public virtual BatchJobHandle ScheduleAfter(TPayload payload, BatchJobHandle job, string groupId, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
+	public virtual BatchJobHandle ScheduleAfter(TPayload payload, BatchJobHandle job, string groupId, ContinuationTrigger on = ContinuationTrigger.Success) =>
+		CaptureBatch(payload, job.Batch, _timeProvider.GetUtcNow(), groupId);
 
 	/// <inheritdoc />
-	public virtual BatchJobHandle ScheduleAfter(TPayload payload, BatchJobHandle job, TimeSpan delay, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
+	public virtual BatchJobHandle ScheduleAfter(TPayload payload, BatchJobHandle job, TimeSpan delay, ContinuationTrigger on = ContinuationTrigger.Success) =>
+		CaptureBatchDelayed(payload, job.Batch, delay, null);
 
 	/// <inheritdoc />
 	public virtual BatchJobHandle ScheduleAfter(
@@ -215,20 +173,20 @@ public class CaptureOnlyJobScheduler<TPayload>(TimeProvider? timeProvider = null
 		BatchJobHandle job,
 		TimeSpan delay,
 		string groupId,
-		CancellationToken cancellationToken = default
-	) => throw new NotImplementedException();
+		ContinuationTrigger on = ContinuationTrigger.Success
+	) => CaptureBatchDelayed(payload, job.Batch, delay, groupId);
 
 	/// <inheritdoc />
-	public virtual BatchJobHandle ScheduleAfter(TPayload payload, IReadOnlyList<BatchJobHandle> jobs, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
+	public virtual BatchJobHandle ScheduleAfter(TPayload payload, IReadOnlyList<BatchJobHandle> jobs, ContinuationTrigger on = ContinuationTrigger.Success) =>
+		CaptureBatch(payload, FirstBatch(jobs), _timeProvider.GetUtcNow(), null);
 
 	/// <inheritdoc />
-	public virtual BatchJobHandle ScheduleAfter(TPayload payload, IReadOnlyList<BatchJobHandle> jobs, string groupId, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
+	public virtual BatchJobHandle ScheduleAfter(TPayload payload, IReadOnlyList<BatchJobHandle> jobs, string groupId, ContinuationTrigger on = ContinuationTrigger.Success) =>
+		CaptureBatch(payload, FirstBatch(jobs), _timeProvider.GetUtcNow(), groupId);
 
 	/// <inheritdoc />
-	public virtual BatchJobHandle ScheduleAfter(TPayload payload, IReadOnlyList<BatchJobHandle> jobs, TimeSpan delay, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
+	public virtual BatchJobHandle ScheduleAfter(TPayload payload, IReadOnlyList<BatchJobHandle> jobs, TimeSpan delay, ContinuationTrigger on = ContinuationTrigger.Success) =>
+		CaptureBatchDelayed(payload, FirstBatch(jobs), delay, null);
 
 	/// <inheritdoc />
 	public virtual BatchJobHandle ScheduleAfter(
@@ -236,12 +194,83 @@ public class CaptureOnlyJobScheduler<TPayload>(TimeProvider? timeProvider = null
 		IReadOnlyList<BatchJobHandle> jobs,
 		TimeSpan delay,
 		string groupId,
-		CancellationToken cancellationToken = default
-	) => throw new NotImplementedException();
+		ContinuationTrigger on = ContinuationTrigger.Success
+	) => CaptureBatchDelayed(payload, FirstBatch(jobs), delay, groupId);
 
 	/// <inheritdoc />
-	public virtual ValueTask CancelAsync(JobHandle job, CancellationToken cancellationToken = default) =>
-		throw new NotImplementedException();
+	public virtual ValueTask CancelAsync(JobHandle job, CancellationToken cancellationToken = default)
+	{
+		ArgumentNullException.ThrowIfNull(job);
+		cancellationToken.ThrowIfCancellationRequested();
+		if (!_captures.Any(capture => string.Equals(capture.Id, job.JobId, StringComparison.Ordinal)))
+			throw new KeyNotFoundException($"Job '{job.JobId}' was not found.");
+		if (!_cancelledIds.Add(job.JobId))
+			throw new ImmediateJobException("Only a non-terminal job can be cancelled.");
+		return ValueTask.CompletedTask;
+	}
+
+	private ValueTask<JobHandle> CaptureDelayedAsync(TPayload payload, TimeSpan delay, string? groupId, CancellationToken cancellationToken)
+	{
+		ValidateDelay(delay);
+		return CaptureAsync(payload, _timeProvider.GetUtcNow() + delay, groupId, cancellationToken);
+	}
+
+	private ValueTask<JobHandle> CaptureAtAsync(TPayload payload, DateTimeOffset at, string? groupId, CancellationToken cancellationToken) =>
+		CaptureAsync(payload, at, groupId, cancellationToken);
+
+	private ValueTask<JobHandle> CaptureAsync(TPayload payload, DateTimeOffset runAt, string? groupId, CancellationToken cancellationToken)
+	{
+		cancellationToken.ThrowIfCancellationRequested();
+		return ValueTask.FromResult(Capture(payload, runAt, groupId));
+	}
+
+	private JobHandle CaptureDelayed(TPayload payload, TimeSpan delay, string? groupId)
+	{
+		ValidateDelay(delay);
+		return Capture(payload, _timeProvider.GetUtcNow() + delay, groupId);
+	}
+
+	private JobHandle Capture(TPayload payload, DateTimeOffset runAt, string? groupId)
+	{
+		groupId = NormalizeGroupId(groupId);
+		var handle = new JobHandle { JobId = CreateId() };
+		_captures.Add(new(handle.JobId, payload, runAt) { GroupId = groupId });
+		return handle;
+	}
+
+	private BatchJobHandle CaptureBatchDelayed(TPayload payload, Batch batch, TimeSpan delay, string? groupId)
+	{
+		ValidateDelay(delay);
+		return CaptureBatch(payload, batch, _timeProvider.GetUtcNow() + delay, groupId);
+	}
+
+	private BatchJobHandle CaptureBatchAt(TPayload payload, Batch batch, DateTimeOffset at, string? groupId) => CaptureBatch(payload, batch, at, groupId);
+
+	private BatchJobHandle CaptureBatch(TPayload payload, Batch batch, DateTimeOffset runAt, string? groupId) =>
+		new() { Batch = batch, JobId = Capture(payload, runAt, groupId) };
+
+	private static Batch FirstBatch(IReadOnlyList<BatchJobHandle> jobs)
+	{
+		ArgumentNullException.ThrowIfNull(jobs);
+		if (jobs.Count == 0)
+			throw new ArgumentException("No prior jobs were provided.", nameof(jobs));
+		return jobs[0].Batch;
+	}
+
+	private static void ValidateDelay(TimeSpan delay)
+	{
+		if (delay < TimeSpan.Zero)
+			ArgumentOutOfRangeException.Throw(nameof(delay), "A job delay cannot be negative.");
+	}
+
+	private static string? NormalizeGroupId(string? groupId)
+	{
+		if (string.IsNullOrWhiteSpace(groupId))
+			return null;
+		if (groupId.Length > 128)
+			throw new ArgumentException("A fair queue group id cannot exceed 128 characters.", nameof(groupId));
+		return groupId;
+	}
 
 	/// <summary>Clears every captured call and cancellation.</summary>
 	public void Clear()

--- a/tests/Immediate.Jobs.FunctionalTests/Packages/NodaTimeTests.cs
+++ b/tests/Immediate.Jobs.FunctionalTests/Packages/NodaTimeTests.cs
@@ -24,7 +24,7 @@ public sealed class NodaTimeTests
 			groupId: "tenant-a",
 			cancellationToken: cancellationToken
 		);
-		_ = await scheduler.ScheduleAtAsync(
+		_ = await scheduler.ScheduleAsync(
 			new("absolute"),
 			start + Duration.FromHours(2),
 			groupId: "tenant-b",
@@ -51,45 +51,45 @@ public sealed class NodaTimeTests
 		);
 		await using var batch = harness.Batches.Begin();
 
-		var delayedBatchMember = scheduler.AddToBatch(
-			batch,
+		var delayedBatchMember = scheduler.Schedule(
 			new("delayed-batch-member"),
+			batch,
 			Duration.FromMinutes(5)
 		);
-		var absoluteBatchMember = scheduler.AddToBatchAt(
-			batch,
+		var absoluteBatchMember = scheduler.Schedule(
 			new("absolute-batch-member"),
+			batch,
 			start + Duration.FromHours(2)
 		);
-		var firstParent = scheduler.AddToBatch(batch, new("first-parent"));
-		var secondParent = scheduler.AddToBatch(batch, new("second-parent"));
+		var firstParent = scheduler.Enqueue(new("first-parent"), batch);
+		var secondParent = scheduler.Enqueue(new("second-parent"), batch);
 		var jobContinuation = await scheduler.ScheduleAfterAsync(
-			firstParent,
 			new("job-continuation"),
+			firstParent.JobId,
 			delay: Duration.FromMinutes(10),
 			cancellationToken: cancellationToken
 		);
 		var fanInContinuation = await scheduler.ScheduleAfterAsync(
-			[firstParent, secondParent],
 			new("fan-in-continuation"),
+			[firstParent.JobId, secondParent.JobId],
 			delay: Duration.FromMinutes(15),
 			cancellationToken: cancellationToken
 		);
 		var batchHandle = await batch.CommitAsync(cancellationToken);
 		var batchContinuation = await scheduler.ScheduleAfterAsync(
-			batchHandle,
 			new("batch-continuation"),
+			batchHandle,
 			delay: Duration.FromMinutes(20),
 			cancellationToken: cancellationToken
 		);
 
 		var jobs = (await harness.QueryJobsAsync(cancellationToken: cancellationToken))
 			.ToDictionary(static job => job.JobId, StringComparer.Ordinal);
-		Assert.Equal(start + Duration.FromMinutes(5), Instant.FromDateTimeOffset(jobs[delayedBatchMember.Id].DueAt));
-		Assert.Equal(start + Duration.FromHours(2), Instant.FromDateTimeOffset(jobs[absoluteBatchMember.Id].DueAt));
-		Assert.Equal(start + Duration.FromMinutes(10), Instant.FromDateTimeOffset(jobs[jobContinuation.Id].DueAt));
-		Assert.Equal(start + Duration.FromMinutes(15), Instant.FromDateTimeOffset(jobs[fanInContinuation.Id].DueAt));
-		Assert.Equal(start + Duration.FromMinutes(20), Instant.FromDateTimeOffset(jobs[batchContinuation.Id].DueAt));
+		Assert.Equal(start + Duration.FromMinutes(5), Instant.FromDateTimeOffset(jobs[delayedBatchMember.JobId.JobId].DueAt));
+		Assert.Equal(start + Duration.FromHours(2), Instant.FromDateTimeOffset(jobs[absoluteBatchMember.JobId.JobId].DueAt));
+		Assert.Equal(start + Duration.FromMinutes(10), Instant.FromDateTimeOffset(jobs[jobContinuation.JobId].DueAt));
+		Assert.Equal(start + Duration.FromMinutes(15), Instant.FromDateTimeOffset(jobs[fanInContinuation.JobId].DueAt));
+		Assert.Equal(start + Duration.FromMinutes(20), Instant.FromDateTimeOffset(jobs[batchContinuation.JobId].DueAt));
 	}
 
 	[Fact]


### PR DESCRIPTION
### Motivation
- Provide NodaTime-friendly overloads so callers can schedule using `NodaTime.Instant` and `NodaTime.Duration` without manual conversions.
- Replace placeholder scheduler test doubles with a working `CaptureOnlyJobScheduler` implementation so tests can exercise scheduling, continuations, batches and cancellation.

### Description
- Added many `Instant` / `Duration` overloads to `NodaTimeJobSchedulerExtensions` that forward to existing APIs by converting to `DateTimeOffset` / `TimeSpan`.
- Implemented `CaptureOnlyJobScheduler<TPayload>` methods previously throwing `NotImplementedException`, including enqueue/schedule/continuation/batch variants, cancellation handling, and internal capture helpers (`Capture*` methods).
- Added validation and normalization in the test scheduler: non-negative delay check (`ValidateDelay`), `NormalizeGroupId` length/whitespace handling, and `CancelAsync` behavior that checks existence and prevents double-cancels.
- Updated functional tests (`NodaTimeTests`) to exercise the new overloads and to adapt assertions to the new shapes of returned handles.

### Testing
- Ran the updated functional tests in `Immediate.Jobs.FunctionalTests` covering `NodaTimeTests`, and they passed.
- Ran unit tests that exercise `CaptureOnlyJobScheduler` behaviors (scheduling, delayed scheduling, batch capture, continuations and cancellation), and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a89afd9586483219a544864cb09693d)